### PR TITLE
Report failure after js ci failures

### DIFF
--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -47,3 +47,8 @@ jobs:
               run: |
                   cd ./frontend
                   pnpm run check-types
+            - name: Check for failures
+              if: steps.eslint.outcome == 'failure' || steps.check-types.outcome == 'failure'
+              run: |
+                  echo "One or more checks failed"
+                  exit 1


### PR DESCRIPTION
We currently do not raise in the ci if the eslint job fails. For example it failed in #72 and was not reported.