### PR TITLE
Fix num preview workers (#68)

### DIFF
--- a/backend/beets_flask/config/config_bf_default.yaml
+++ b/backend/beets_flask/config/config_bf_default.yaml
@@ -6,7 +6,7 @@
 # to get started, see the auto-generated examples in /config/beets-flask/
 
 gui:
-    num_workers_preview: 4
+    num_preview_workers: 4
 
     library:
         readonly: no

--- a/backend/beets_flask/config/config_bf_example.yaml
+++ b/backend/beets_flask/config/config_bf_example.yaml
@@ -8,7 +8,7 @@
 # your docker-compose.yml.
 
 gui:
-    num_workers_preview: 4 # how many previews to generate in parallel
+    num_preview_workers: 4 # how many previews to generate in parallel
 
     library:
         readonly: no


### PR DESCRIPTION
For some reason the variable was named incorrectly in the default config. Maybe we renamed it at some point?

closes #68 