### PR TITLE
Fix log directory and level

### DIFF
--- a/backend/beets_flask/logger.py
+++ b/backend/beets_flask/logger.py
@@ -38,7 +38,7 @@ LOGGING_CONFIG = {
         },
         "beets-flask": {
             "handlers": ["console", "file"],
-            "level": os.getenv("LOG_LEVEL_BEETSFLASK", logging.DEBUG),
+            "level": os.getenv("LOG_LEVEL_BEETSFLASK", logging.INFO),
             "propagate": False,
         },
     },

--- a/backend/beets_flask/logger.py
+++ b/backend/beets_flask/logger.py
@@ -11,7 +11,7 @@ LOGGING_CONFIG = {
             "format": "[%(levelname)s] %(name)s: %(message)s"
         },
         "debug": {
-            "format": "%(relativeCreated)-8d [%(levelname)-5s] %(name)s %(filename)-8s:%(lineno)d %(message)s"
+            "format": "[%(levelname)-5s] %(asctime)s %(name)s %(filename)-8s:%(lineno)d %(message)s"
         },
     },
     "handlers": {
@@ -25,8 +25,8 @@ LOGGING_CONFIG = {
             "class": "logging.handlers.RotatingFileHandler",
             "level": "DEBUG",
             "formatter": "debug",
-            "filename": os.environ.get("LOG_FILE_WEB", "./beets-flask.log"),
-            "maxBytes": 1048576,  #
+            "filename": os.environ.get("BEETSFLASKLOG", "./beets-flask.log"),
+            "maxBytes": 1048576,  # 1 MB
             "backupCount": 3,
         },
     },
@@ -49,7 +49,7 @@ if "PYTEST_VERSION" in os.environ:
     # Configure minimal logging for pytest
     logging.basicConfig(
         level=logging.DEBUG,
-        format="%(relativeCreated)-8d [%(levelname)-5s] %(name)s %(filename)-8s:%(lineno)d %(message)s",
+        format="[%(levelname)-5s] %(asctime)s %(name)s %(filename)-8s:%(lineno)d %(message)s",
     )
 else:
     logging.config.dictConfig(LOGGING_CONFIG)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,15 +11,16 @@ ENV HOSTNAME="beets-container"
 # map beets directory and our configs to /config
 RUN mkdir -p /config/beets
 RUN mkdir -p /config/beets-flask
+RUN mkdir -p /logs
 RUN chown -R beetle:beetle /config
+RUN chown -R beetle:beetle /logs
 ENV BEETSDIR="/config/beets"
 ENV BEETSFLASKDIR="/config/beets-flask"
-ENV LOG_FILE_WEB="/repo/log/web.log"
+ENV BEETSFLASKLOG="/logs/beets-flask.log"
 
 # our default folders they should not be used in production
 RUN mkdir -p /music/inbox
 RUN mkdir -p /music/imported
-RUN mkdir -p /repo/log
 RUN chown -R beetle:beetle /music
 
 # dependencies

--- a/docker/docker-compose.dev.yaml
+++ b/docker/docker-compose.dev.yaml
@@ -28,5 +28,9 @@ services:
             # get permission issues.
             - ../local/config/:/config
 
+            # For debugging purposes, you can also mount the logs directory
+            # for instance if you want to report an issue
+            - ../local/logs/:/logs
+
             # for development. (disable if target is `prod`)
             - ../:/repo/

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -13,3 +13,5 @@ services:
             # for music folders, match paths inside and out of container!
             - /music_path/inbox/:/music_path/inbox/
             - /music_path/clean/:/music_path/clean/
+            # If you want to persist the logs, you can mount a logs directory
+            # - /wherever/logs/:/logs

--- a/docker/entrypoints/entrypoint_test.sh
+++ b/docker/entrypoints/entrypoint_test.sh
@@ -12,6 +12,8 @@ python ./launch_redis_workers.py
 
 redis-cli FLUSHALL
 
+# This might be broken! Not sure where this entrypoint is even used!
+# log dir changed!
 mkdir -p /repo/log
 rm /repo/log/for_web.log >/dev/null 2>&1
 rm /repo/frontend/vite.config.ts.timestamp-*.mjs >/dev/null 2>&1

--- a/docs/develop/resources/backend.md
+++ b/docs/develop/resources/backend.md
@@ -21,6 +21,7 @@ The configuration folders can be set via environment variables. This might be us
 ```
 BEETSDIR="/config/beets"
 BEETSFLASKDIR="/config/beets-flask"
+BEETSFLASKLOG="/logs/beets-flask.log"
 ```
 
 


### PR DESCRIPTION
Replace "WEB_LOG" variable with "BEETSFLASKLOG" as we do not have a web
log anymore. Also changed the default folder of the logs for docker
builds. 

By default the log level is set to info.

closes #44