### PR TITLE
Entrypoint logging and version string

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -31,3 +31,4 @@
 !README.md
 !LICENSE
 !docker/entrypoints/entrypoint*.sh
+!docker/entrypoints/common.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -132,6 +132,7 @@ COPY --from=build /repo/frontend/dist /repo/frontend/dist
 COPY docker/entrypoints/entrypoint.sh .
 COPY docker/entrypoints/entrypoint_user_scripts.sh .
 COPY docker/entrypoints/entrypoint_fix_permissions.sh .
+COPY docker/entrypoints/common.sh .
 RUN chown -R beetle:beetle /repo
 
 USER root

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -62,6 +62,10 @@ COPY ./backend/launch_redis_workers.py /repo/backend/
 
 RUN uv sync
 
+# Extract version from pyproject.toml
+RUN mkdir -p /version
+RUN python -c "import tomllib; print(tomllib.load(open('/repo/backend/pyproject.toml', 'rb'))['project']['version'])" > /version/backend.txt
+
 # ------------------------------------------------------------------------------------ #
 #                                      Development                                     #
 # ------------------------------------------------------------------------------------ #
@@ -74,6 +78,19 @@ RUN --mount=type=cache,target=/var/cache/apk \
 
 RUN npm install -g pnpm
 RUN pnpm config set store-dir /repo/frontend/.pnpm-store
+
+# Copy the lock files and install dependencies
+WORKDIR /repo
+COPY ./frontend/package.json /repo/frontend/
+COPY ./frontend/pnpm-lock.yaml /repo/frontend/
+
+WORKDIR /repo/frontend
+RUN pnpm i
+
+# Extract version from package.json
+RUN mkdir -p /version
+RUN python -c "import json; print(json.load(open('/repo/frontend/package.json'))['version'])" \
+    > /version/frontend.txt
 
 ENV IB_SERVER_CONFIG="dev_docker"
 
@@ -113,11 +130,19 @@ WORKDIR /repo
 COPY ./frontend ./frontend/
 RUN chown -R beetle:beetle /repo
 
+# Extract version from package.json
+RUN mkdir -p /version
+RUN python -c "import json; print(json.load(open('/repo/frontend/package.json'))['version'])" \
+    > /version/frontend.txt
+
 USER beetle
 WORKDIR /repo/frontend
 # RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
 RUN pnpm install
 RUN pnpm run build
+
+
+
 
 # ------------------------------------------------------------------------------------ #
 #                                      Production                                      #
@@ -129,6 +154,7 @@ ENV IB_SERVER_CONFIG="prod"
 
 WORKDIR /repo
 COPY --from=build /repo/frontend/dist /repo/frontend/dist
+COPY --from=build /version /version
 COPY docker/entrypoints/entrypoint.sh .
 COPY docker/entrypoints/entrypoint_user_scripts.sh .
 COPY docker/entrypoints/entrypoint_fix_permissions.sh .

--- a/docker/entrypoints/common.sh
+++ b/docker/entrypoints/common.sh
@@ -1,0 +1,38 @@
+# A number of common functions used by entrypoints
+
+log() {
+    echo -e "[Entrypoint] $1"
+}
+
+log_error() {
+    echo -e "\033[0;31m[Entrypoint] $1\033[0m"
+}
+
+log_current_user() {
+    log "Running as '$(whoami)' with UID $(id -u) and GID $(id -g)"
+    log "Current working directory: $(pwd)"
+}
+
+log_version_info() {
+    log "Version info:"
+    log "  Backend:  $BACKEND_VERSION"
+    log "  Frontend: $FRONTEND_VERSION"
+    log "  Mode:     $IB_SERVER_CONFIG"
+}
+
+get_version_info() {
+    if [ -f /version/backend.txt ]; then
+        export BACKEND_VERSION=$(cat /version/backend.txt)
+    else
+        export BACKEND_VERSION="unk"
+    fi
+
+    if [ -f /version/frontend.txt ]; then
+        export FRONTEND_VERSION=$(cat /version/frontend.txt)
+    else
+        export FRONTEND_VERSION="unk"
+    fi
+}
+
+# Populate the environment variables for the version info
+get_version_info

--- a/docker/entrypoints/entrypoint_dev.sh
+++ b/docker/entrypoints/entrypoint_dev.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
+source ./docker/entrypoints/common.sh
 
-whoami
-id
-pwd
+log_current_user
+log_version_info
+log "Starting development environment..."
 
 cd /repo/frontend
 

--- a/docker/entrypoints/entrypoint_fix_permissions.sh
+++ b/docker/entrypoints/entrypoint_fix_permissions.sh
@@ -1,9 +1,8 @@
 #!/bin/sh
 
 if [ ! -z "$USER_ID" ] && [ ! -z "$GROUP_ID" ]; then
-    echo "Updating UID to $USER_ID and GID to $GROUP_ID"
     groupmod -g $GROUP_ID beetle
-    usermod -u $USER_ID -g $GROUP_ID beetle
+    usermod -u $USER_ID -g $GROUP_ID beetle > /dev/null 2>&1
     chown -R beetle:beetle /home/beetle
     chown -R beetle:beetle /repo
 fi

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "frontend",
     "private": true,
-    "version": "0.1.0",
+    "version": "1.0.0",
     "type": "module",
     "scripts": {
         "dev": "vite --host --cors",
@@ -37,6 +37,7 @@
         "@tanstack/eslint-plugin-query": "^5.78.0",
         "@tanstack/router-vite-plugin": "^1.120.13",
         "@types/diff": "^5.2.3",
+        "@types/node": "^24.0.0",
         "@types/react": "^18.3.23",
         "@types/react-dom": "^18.3.7",
         "@types/react-window": "^1.8.8",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -77,10 +77,13 @@ importers:
         version: 5.78.0(eslint@9.28.0(jiti@1.21.7))(typescript@5.8.3)
       '@tanstack/router-vite-plugin':
         specifier: ^1.120.13
-        version: 1.120.13(@tanstack/react-router@1.120.13(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite@6.3.5(jiti@1.21.7)(sass@1.89.1)(tsx@4.19.4))
+        version: 1.120.13(@tanstack/react-router@1.120.13(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite@6.3.5(@types/node@24.0.0)(jiti@1.21.7)(sass@1.89.1)(tsx@4.19.4))
       '@types/diff':
         specifier: ^5.2.3
         version: 5.2.3
+      '@types/node':
+        specifier: ^24.0.0
+        version: 24.0.0
       '@types/react':
         specifier: ^18.3.23
         version: 18.3.23
@@ -98,10 +101,10 @@ importers:
         version: 8.33.0(eslint@9.28.0(jiti@1.21.7))(typescript@5.8.3)
       '@vitejs/plugin-react':
         specifier: ^4.5.0
-        version: 4.5.0(vite@6.3.5(jiti@1.21.7)(sass@1.89.1)(tsx@4.19.4))
+        version: 4.5.0(vite@6.3.5(@types/node@24.0.0)(jiti@1.21.7)(sass@1.89.1)(tsx@4.19.4))
       '@vitejs/plugin-react-swc':
         specifier: ^3.10.0
-        version: 3.10.0(vite@6.3.5(jiti@1.21.7)(sass@1.89.1)(tsx@4.19.4))
+        version: 3.10.0(vite@6.3.5(@types/node@24.0.0)(jiti@1.21.7)(sass@1.89.1)(tsx@4.19.4))
       babel-plugin-react-compiler:
         specifier: 19.1.0-rc.2
         version: 19.1.0-rc.2
@@ -137,13 +140,13 @@ importers:
         version: 8.33.0(eslint@9.28.0(jiti@1.21.7))(typescript@5.8.3)
       vite:
         specifier: ^6.3.5
-        version: 6.3.5(jiti@1.21.7)(sass@1.89.1)(tsx@4.19.4)
+        version: 6.3.5(@types/node@24.0.0)(jiti@1.21.7)(sass@1.89.1)(tsx@4.19.4)
       vite-plugin-svgr:
         specifier: ^4.3.0
-        version: 4.3.0(rollup@4.40.2)(typescript@5.8.3)(vite@6.3.5(jiti@1.21.7)(sass@1.89.1)(tsx@4.19.4))
+        version: 4.3.0(rollup@4.40.2)(typescript@5.8.3)(vite@6.3.5(@types/node@24.0.0)(jiti@1.21.7)(sass@1.89.1)(tsx@4.19.4))
       vite-tsconfig-paths:
         specifier: ^4.3.2
-        version: 4.3.2(typescript@5.8.3)(vite@6.3.5(jiti@1.21.7)(sass@1.89.1)(tsx@4.19.4))
+        version: 4.3.2(typescript@5.8.3)(vite@6.3.5(@types/node@24.0.0)(jiti@1.21.7)(sass@1.89.1)(tsx@4.19.4))
 
 packages:
 
@@ -1295,6 +1298,9 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/node@24.0.0':
+    resolution: {integrity: sha512-yZQa2zm87aRVcqDyH5+4Hv9KYgSdgwX1rFnGvpbzMaC7YAljmhBET93TPiTd3ObwTL+gSpIzPKg5BqVxdCvxKg==}
 
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
@@ -2635,6 +2641,9 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
+  undici-types@7.8.0:
+    resolution: {integrity: sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==}
+
   unplugin@2.3.5:
     resolution: {integrity: sha512-RyWSb5AHmGtjjNQ6gIlA67sHOsWpsbWpwDokLwTcejVdOjEkJZh7QKu14J00gDDVSh8kGH4KYC/TNBceXFZhtw==}
     engines: {node: '>=18.12.0'}
@@ -3759,7 +3768,7 @@ snapshots:
     optionalDependencies:
       '@tanstack/react-router': 1.120.13(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
 
-  '@tanstack/router-plugin@1.120.13(@tanstack/react-router@1.120.13(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite@6.3.5(jiti@1.21.7)(sass@1.89.1)(tsx@4.19.4))':
+  '@tanstack/router-plugin@1.120.13(@tanstack/react-router@1.120.13(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite@6.3.5(@types/node@24.0.0)(jiti@1.21.7)(sass@1.89.1)(tsx@4.19.4))':
     dependencies:
       '@babel/core': 7.27.4
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.27.4)
@@ -3780,7 +3789,7 @@ snapshots:
       zod: 3.25.48
     optionalDependencies:
       '@tanstack/react-router': 1.120.13(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      vite: 6.3.5(jiti@1.21.7)(sass@1.89.1)(tsx@4.19.4)
+      vite: 6.3.5(@types/node@24.0.0)(jiti@1.21.7)(sass@1.89.1)(tsx@4.19.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -3791,9 +3800,9 @@ snapshots:
       ansis: 3.17.0
       diff: 7.0.0
 
-  '@tanstack/router-vite-plugin@1.120.13(@tanstack/react-router@1.120.13(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite@6.3.5(jiti@1.21.7)(sass@1.89.1)(tsx@4.19.4))':
+  '@tanstack/router-vite-plugin@1.120.13(@tanstack/react-router@1.120.13(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite@6.3.5(@types/node@24.0.0)(jiti@1.21.7)(sass@1.89.1)(tsx@4.19.4))':
     dependencies:
-      '@tanstack/router-plugin': 1.120.13(@tanstack/react-router@1.120.13(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite@6.3.5(jiti@1.21.7)(sass@1.89.1)(tsx@4.19.4))
+      '@tanstack/router-plugin': 1.120.13(@tanstack/react-router@1.120.13(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite@6.3.5(@types/node@24.0.0)(jiti@1.21.7)(sass@1.89.1)(tsx@4.19.4))
     transitivePeerDependencies:
       - '@rsbuild/core'
       - '@tanstack/react-router'
@@ -3834,6 +3843,10 @@ snapshots:
   '@types/estree@1.0.7': {}
 
   '@types/json-schema@7.0.15': {}
+
+  '@types/node@24.0.0':
+    dependencies:
+      undici-types: 7.8.0
 
   '@types/parse-json@4.0.2': {}
 
@@ -3985,15 +3998,15 @@ snapshots:
       '@typescript-eslint/types': 8.33.0
       eslint-visitor-keys: 4.2.0
 
-  '@vitejs/plugin-react-swc@3.10.0(vite@6.3.5(jiti@1.21.7)(sass@1.89.1)(tsx@4.19.4))':
+  '@vitejs/plugin-react-swc@3.10.0(vite@6.3.5(@types/node@24.0.0)(jiti@1.21.7)(sass@1.89.1)(tsx@4.19.4))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.9
       '@swc/core': 1.11.24
-      vite: 6.3.5(jiti@1.21.7)(sass@1.89.1)(tsx@4.19.4)
+      vite: 6.3.5(@types/node@24.0.0)(jiti@1.21.7)(sass@1.89.1)(tsx@4.19.4)
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@vitejs/plugin-react@4.5.0(vite@6.3.5(jiti@1.21.7)(sass@1.89.1)(tsx@4.19.4))':
+  '@vitejs/plugin-react@4.5.0(vite@6.3.5(@types/node@24.0.0)(jiti@1.21.7)(sass@1.89.1)(tsx@4.19.4))':
     dependencies:
       '@babel/core': 7.27.1
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.27.1)
@@ -4001,7 +4014,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.9
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.3.5(jiti@1.21.7)(sass@1.89.1)(tsx@4.19.4)
+      vite: 6.3.5(@types/node@24.0.0)(jiti@1.21.7)(sass@1.89.1)(tsx@4.19.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -5489,6 +5502,8 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
+  undici-types@7.8.0: {}
+
   unplugin@2.3.5:
     dependencies:
       acorn: 8.14.1
@@ -5509,29 +5524,29 @@ snapshots:
     dependencies:
       react: 19.1.0
 
-  vite-plugin-svgr@4.3.0(rollup@4.40.2)(typescript@5.8.3)(vite@6.3.5(jiti@1.21.7)(sass@1.89.1)(tsx@4.19.4)):
+  vite-plugin-svgr@4.3.0(rollup@4.40.2)(typescript@5.8.3)(vite@6.3.5(@types/node@24.0.0)(jiti@1.21.7)(sass@1.89.1)(tsx@4.19.4)):
     dependencies:
       '@rollup/pluginutils': 5.1.4(rollup@4.40.2)
       '@svgr/core': 8.1.0(typescript@5.8.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.8.3))
-      vite: 6.3.5(jiti@1.21.7)(sass@1.89.1)(tsx@4.19.4)
+      vite: 6.3.5(@types/node@24.0.0)(jiti@1.21.7)(sass@1.89.1)(tsx@4.19.4)
     transitivePeerDependencies:
       - rollup
       - supports-color
       - typescript
 
-  vite-tsconfig-paths@4.3.2(typescript@5.8.3)(vite@6.3.5(jiti@1.21.7)(sass@1.89.1)(tsx@4.19.4)):
+  vite-tsconfig-paths@4.3.2(typescript@5.8.3)(vite@6.3.5(@types/node@24.0.0)(jiti@1.21.7)(sass@1.89.1)(tsx@4.19.4)):
     dependencies:
       debug: 4.4.0
       globrex: 0.1.2
       tsconfck: 3.1.5(typescript@5.8.3)
     optionalDependencies:
-      vite: 6.3.5(jiti@1.21.7)(sass@1.89.1)(tsx@4.19.4)
+      vite: 6.3.5(@types/node@24.0.0)(jiti@1.21.7)(sass@1.89.1)(tsx@4.19.4)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@6.3.5(jiti@1.21.7)(sass@1.89.1)(tsx@4.19.4):
+  vite@6.3.5(@types/node@24.0.0)(jiti@1.21.7)(sass@1.89.1)(tsx@4.19.4):
     dependencies:
       esbuild: 0.25.4
       fdir: 6.4.4(picomatch@4.0.2)
@@ -5540,6 +5555,7 @@ snapshots:
       rollup: 4.40.2
       tinyglobby: 0.2.13
     optionalDependencies:
+      '@types/node': 24.0.0
       fsevents: 2.3.3
       jiti: 1.21.7
       sass: 1.89.1

--- a/frontend/src/routes/_frontpage/index.tsx
+++ b/frontend/src/routes/_frontpage/index.tsx
@@ -152,6 +152,13 @@ function Hero() {
 
 function Footer() {
     const theme = useTheme();
+
+    let versionString = `v${__FRONTEND_VERSION__}`;
+    if (__MODE__ !== "production") {
+        // Append the mode to the version string if not in production
+        versionString += ` (${__MODE__})`;
+    }
+
     return (
         <Box
             sx={(theme) => ({
@@ -179,7 +186,7 @@ function Footer() {
                 variant="caption"
                 sx={{ color: "grey.700", mr: "auto", alignSelf: "flex-end" }}
             >
-                &copy; 2025 P. Spitzner &amp; S. Mohr
+                {versionString} - &copy; 2025 P. Spitzner &amp; S. Mohr
             </Typography>
 
             <Link

--- a/frontend/src/routes/_frontpage/index.tsx
+++ b/frontend/src/routes/_frontpage/index.tsx
@@ -186,7 +186,7 @@ function Footer() {
                 variant="caption"
                 sx={{ color: "grey.700", mr: "auto", alignSelf: "flex-end" }}
             >
-                {versionString} - &copy; 2025 P. Spitzner &amp; S. Mohr
+                {versionString} &copy; 2025 P. Spitzner &amp; S. Mohr
             </Typography>
 
             <Link

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,2 +1,5 @@
 /// <reference types="vite/client" />
 /// <reference types="vite-plugin-svgr/client" />
+
+declare const __FRONTEND_VERSION__: string;
+declare const __MODE__: string;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -65,5 +65,12 @@ export default defineConfig(({ mode }) => {
                 },
             },
         },
+        define: {
+            // Load from package.json
+            __FRONTEND_VERSION__: JSON.stringify(
+                process.env.npm_package_version || "unk"
+            ),
+            __MODE__: JSON.stringify(mode),
+        },
     };
 });

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -32,7 +32,7 @@ export default defineConfig(({ mode }) => {
         // not minifying helped when debugging in production mode
         // we can enable this again when the code base is a bit more mature.
         build: {
-            minify: false,
+            minify: isProd,
         },
         css: {
             preprocessorOptions: {


### PR DESCRIPTION
## Console spam 

Console on initial start is spammed with warnings from click (interaction with rq). This disables all warnings in production, now looks like this on startup:

![image](https://github.com/user-attachments/assets/19accc38-fa30-446a-ad0d-e2471a6fed57)

## Version string

Adds a version string to the bottom of the footer on the frontpage:

In dev:
![image](https://github.com/user-attachments/assets/190d7b00-33d8-4cbc-a36b-28db48e767aa)
In prod:
![image](https://github.com/user-attachments/assets/55b37d70-d556-47c5-9b2e-dc3dcc0e8d28)

## Minification

This PR also re-enables minification in the vite transpile step. Bundle size -50kb :tada: 
