### PR TITLE
Disk watchdog should not run in uvicorn workers.

### DIFF
--- a/backend/beets_flask/database/setup.py
+++ b/backend/beets_flask/database/setup.py
@@ -1,5 +1,6 @@
 from contextlib import contextmanager
 from functools import wraps
+from typing import Optional
 
 from deprecated import deprecated
 from quart import Quart
@@ -15,7 +16,7 @@ engine: Engine | None = None
 session_factory: scoped_session[Session]
 
 
-def setup_database(app: Quart) -> None:
+def setup_database(app: Optional[Quart] = None) -> None:
     """Set up the database connection and session factory for the FLask application.
 
     This function initializes the global `engine` and `session_factory` variables
@@ -37,10 +38,12 @@ def setup_database(app: Quart) -> None:
 
     _create_tables(engine)
 
-    # Gracefully shutdown the database session
-    @app.teardown_appcontext
-    def shutdown_session(exception=None) -> None:
-        session_factory.remove()
+    if app is not None:
+        # Gracefully shutdown the database session, if launched
+        # from within a Flask app context.
+        @app.teardown_appcontext
+        def shutdown_session(exception=None) -> None:
+            session_factory.remove()
 
 
 def __setup_factory():

--- a/backend/beets_flask/server/app.py
+++ b/backend/beets_flask/server/app.py
@@ -42,10 +42,6 @@ def create_app(config: str | ServerConfig | None = None) -> Quart:
     register_routes(app)
     register_socketio(app)
 
-    from ..watchdog.inbox import register_inboxes
-
-    register_inboxes()
-
     log.debug("Quart app created!")
 
     return app

--- a/backend/beets_flask/watchdog/inbox.py
+++ b/backend/beets_flask/watchdog/inbox.py
@@ -50,13 +50,6 @@ def register_inboxes(timeout: float = 2.5, debounce: float = 30) -> AIOWatchdog 
         log.exception("WTF, redis what you doing?")
         return None
 
-    if os.getpid() != os.getppid():
-        log.exception(
-            "This is a child process (likely uvicorn worker), "
-            + "not starting inbox watchdog."
-        )
-        return None
-
     # Return early if no inboxes are configured.
     if len(_inboxes) == 0:
         return None

--- a/backend/beets_flask/watchdog/inbox.py
+++ b/backend/beets_flask/watchdog/inbox.py
@@ -30,8 +30,6 @@ def register_inboxes(timeout: float = 2.5, debounce: float = 30) -> AIOWatchdog 
     """
     Register file system watcher to monitor configured inboxes.
 
-    This should not be called from web workers.
-
     Parameters
     ----------
     timeout: float
@@ -42,6 +40,11 @@ def register_inboxes(timeout: float = 2.5, debounce: float = 30) -> AIOWatchdog 
         You have to wait at least this long before an autotag will trigger
         after you add the last file to an inbox.
         Default is 30 seconds.
+
+    Notes
+    -----
+    - This should not be called from uvicorn workers to avoid concurrency issues.
+      You only want one watchdog (use separate init script).
     """
     _inboxes = get_inboxes()
 

--- a/backend/launch_db_init.py
+++ b/backend/launch_db_init.py
@@ -1,0 +1,21 @@
+import os
+
+# dirty workaround, we pretend this is a rq worker so we get the logger to create
+# a child log with pid
+os.environ.setdefault("RQ_JOB_ID", "dbin")
+
+from beets.ui import _open_library
+
+from beets_flask.config.beets_config import get_config
+from beets_flask.database import setup_database
+from beets_flask.logger import log
+
+if __name__ == "__main__":
+    log.debug("Launching database init worker")
+
+    # ensue beets own db is created
+    config = get_config()
+    _open_library(config)
+
+    # ensure beets-flask db is created
+    setup_database()

--- a/backend/launch_watchdog_worker.py
+++ b/backend/launch_watchdog_worker.py
@@ -1,0 +1,13 @@
+import asyncio
+
+from beets_flask.logger import log
+from beets_flask.watchdog.inbox import register_inboxes
+
+if __name__ == "__main__":
+    log.debug(f"Launching inbox watchdog worker")
+    watchdog = register_inboxes()
+    if watchdog:
+        try:
+            asyncio.get_event_loop().run_forever()
+        except KeyboardInterrupt:
+            watchdog.stop()

--- a/backend/launch_watchdog_worker.py
+++ b/backend/launch_watchdog_worker.py
@@ -1,13 +1,19 @@
 import asyncio
+import os
+
+# dirty workaround, we pretend this is a rq worker so we get the logger to create
+# a child log with pid
+os.environ.setdefault("RQ_JOB_ID", "wdog")
 
 from beets_flask.logger import log
 from beets_flask.watchdog.inbox import register_inboxes
 
-if __name__ == "__main__":
+
+async def main():
     log.debug(f"Launching inbox watchdog worker")
     watchdog = register_inboxes()
-    if watchdog:
-        try:
-            asyncio.get_event_loop().run_forever()
-        except KeyboardInterrupt:
-            watchdog.stop()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+    asyncio.get_event_loop().run_forever()

--- a/docker/entrypoints/entrypoint.sh
+++ b/docker/entrypoints/entrypoint.sh
@@ -23,7 +23,13 @@ cd /repo/backend
 
 redis-server --daemonize yes >/dev/null 2>&1
 
+
+# blocking
+python ./launch_db_init.py
 python ./launch_redis_workers.py > /logs/redis_workers.log 2>&1
+
+# keeps running in the background
+python ./launch_watchdog_worker.py &
 
 redis-cli FLUSHALL >/dev/null 2>&1
 

--- a/docker/entrypoints/entrypoint_dev.sh
+++ b/docker/entrypoints/entrypoint_dev.sh
@@ -32,6 +32,7 @@ cd /repo/backend
 redis-server --daemonize yes
 
 python ./launch_redis_workers.py
+python ./launch_watchdog_worker.py
 
 redis-cli FLUSHALL
 
@@ -49,8 +50,8 @@ python ./generate_types.py
 uvicorn beets_flask.server.app:create_app --port 5001 \
     --host 0.0.0.0 \
     --factory \
-    --workers 1 \
-    --reload
+    --workers 4
+    # --reload
 
 
 

--- a/docker/entrypoints/entrypoint_dev.sh
+++ b/docker/entrypoints/entrypoint_dev.sh
@@ -31,8 +31,13 @@ cd /repo/backend
 
 redis-server --daemonize yes
 
+
+# blocking
+python ./launch_db_init.py
 python ./launch_redis_workers.py
-python ./launch_watchdog_worker.py
+
+# keeps running in the background
+python ./launch_watchdog_worker.py &
 
 redis-cli FLUSHALL
 
@@ -50,8 +55,9 @@ python ./generate_types.py
 uvicorn beets_flask.server.app:create_app --port 5001 \
     --host 0.0.0.0 \
     --factory \
-    --workers 4
-    # --reload
+    --workers 1 \
+    --use-colors \
+    --reload
 
 
 

--- a/docker/entrypoints/entrypoint_fix_permissions.sh
+++ b/docker/entrypoints/entrypoint_fix_permissions.sh
@@ -5,4 +5,5 @@ if [ ! -z "$USER_ID" ] && [ ! -z "$GROUP_ID" ]; then
     usermod -u $USER_ID -g $GROUP_ID beetle > /dev/null 2>&1
     chown -R beetle:beetle /home/beetle
     chown -R beetle:beetle /repo
+    chown -R beetle:beetle /logs
 fi


### PR DESCRIPTION
WIP fix for #99 

Likely a consequence of #67 
-> Each quart worker starts a watchdog.

Tried to only start a watchdog only in the first worker but thats dirty - but we should really launch the watchdog in a separate thread like we do with the redis workers.