### PR TITLE
Include new boot scripts in dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -59,6 +59,8 @@ RUN uv sync --no-install-project
 COPY ./backend/beets_flask/ /repo/backend/beets_flask/
 COPY ./backend/generate_types.py /repo/backend/
 COPY ./backend/launch_redis_workers.py /repo/backend/
+COPY ./backend/launch_watchdog_workers.py /repo/backend/
+COPY ./backend/launch_db_init.py /repo/backend/
 
 RUN uv sync
 


### PR DESCRIPTION
We forgot to include the new boot scripts for the watchdog and db init in the previous PRs.

