### PR TITLE
Cover art placeholder on 404 errors

### DIFF
--- a/frontend/src/components/library/coverArt.tsx
+++ b/frontend/src/components/library/coverArt.tsx
@@ -52,6 +52,13 @@ export function CoverArt({
 
     if (isError) {
         if (error instanceof APIError) {
+            // Depending on the error we show a placeholder or an error message
+            if (error.statusCode === 404) {
+                // 404 means no cover art found, so we show a placeholder
+                return (
+                    <CoverArtPlaceholder sx={coverSx} animation={false} {...props} />
+                );
+            }
             return <CoverArtError sx={coverSx} error={error} size={size} {...props} />;
         } else {
             throw error;


### PR DESCRIPTION
Instead of showing an error we now show the placeholder if no artwork is available but the file exists.

closes #118


Here the first album no cover art is available and for the second I deleted all imported files.
![image](https://github.com/user-attachments/assets/7f95a876-3f4c-4d2c-b990-cf86a62ff4d2)
