### PR TITLE
Fix filesystem updates not triggered by watchdog (#119)

### DIFF
--- a/backend/beets_flask/disk.py
+++ b/backend/beets_flask/disk.py
@@ -301,6 +301,13 @@ def dir_files(path: Path) -> int:
         return -1
 
 
+def clear_cache():
+    """Clear the cache for all cached functions."""
+    path_to_folder.cache.clear()  # type: ignore
+    dir_size.cache.clear()  # type: ignore
+    dir_files.cache.clear()  # type: ignore
+
+
 __all__ = [
     "dir_size",
 ]

--- a/backend/beets_flask/server/websocket/status.py
+++ b/backend/beets_flask/server/websocket/status.py
@@ -15,6 +15,7 @@ from quart import json
 
 from beets_flask.database import db_session_factory
 from beets_flask.database.models.states import FolderInDb
+from beets_flask.disk import clear_cache
 from beets_flask.importer.progress import FolderStatus
 from beets_flask.invoker.job import JobMeta
 from beets_flask.logger import log
@@ -83,6 +84,7 @@ async def job_update(sid, data):
 @sio_catch_exception
 async def fs_update(sid, data):
     log.debug(f"file_system_update: {data}")
+    clear_cache()
     await sio.emit("file_system_update", data, namespace=namespace)
 
 

--- a/backend/beets_flask/watchdog/inbox.py
+++ b/backend/beets_flask/watchdog/inbox.py
@@ -111,7 +111,6 @@ class InboxHandler(AIOEventHandler):
             return
 
         # trigger cache clear and gui update of inbox directories
-        path_to_folder.cache.clear()  # type: ignore
         status_update = asyncio.create_task(send_status_update(FileSystemUpdate()))
 
         try:


### PR DESCRIPTION
Added clear cache function to disk utils. Called on status update in each worker.

closes #119 