### PR TITLE
Restyled bottom bar on mobile and added translucent effect.

### DIFF
--- a/frontend/src/components/frontpage/navbar.tsx
+++ b/frontend/src/components/frontpage/navbar.tsx
@@ -6,54 +6,123 @@ import Tab, { tabClasses, TabProps } from "@mui/material/Tab";
 import Tabs, { tabsClasses } from "@mui/material/Tabs";
 import { createLink, LinkProps, useRouterState } from "@tanstack/react-router";
 
+export const NAVBAR_HEIGHT = {
+    desktop: "48px",
+    mobile: "74px",
+};
+
+const StyledTabs = styled(Tabs)(({ theme }) => ({
+    color: "inherit",
+    overflow: "hidden",
+    display: "flex",
+    width: "100%",
+    justifyContent: "center",
+    [`& .${tabsClasses.indicator}`]: {
+        position: "absolute",
+        top: `calc(50% - 8px)`,
+        height: "16px",
+        filter: "blur(50px)",
+        backgroundColor: theme.palette.secondary.main,
+        zIndex: -1,
+    },
+    [`& .MuiTabs-scroller`]: {
+        width: "100%",
+        overflow: "visible",
+    },
+    // Spacing of tabs for different breakpoints
+    [`& .MuiTabs-flexContainer`]: {
+        width: "100%",
+        gap: "4px",
+        justifyContent: "center",
+        [theme.breakpoints.up("laptop")]: {
+            gap: "30px",
+        },
+    },
+    [`&:hover .mouse-trail`]: {
+        opacity: 1,
+    },
+
+    // Mobile grid for equal spacing
+    [theme.breakpoints.down("laptop")]: {
+        "& .MuiTabs-list": {
+            width: "auto",
+            display: "grid",
+            gridTemplateColumns: "repeat(5, 1fr)",
+            gridTemplateRows: "1fr",
+            alignItems: "center",
+            justifyItems: "center",
+        },
+        "& .MuiTabs-scroller": {
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+        },
+    },
+}));
+
 interface StyledTabProps extends Omit<LinkProps, "children">, Omit<TabProps, "ref"> {
     label: string | ReactElement;
 }
 
-const StyledTab = createLink(
-    styled(Tab)<StyledTabProps>(({ theme }) => ({
-        lineHeight: "inherit",
-        marginTop: 7,
-        minHeight: 32,
+const StyledTab = styled(createLink(Tab))<StyledTabProps>(({ theme }) => ({
+    lineHeight: "inherit",
+    marginTop: 7,
+    minHeight: 32,
+    minWidth: 0,
+    flexDirection: "row",
+    letterSpacing: "1px",
+    justifyContent: "center",
+    gap: "0.5rem",
+    textTransform: "uppercase",
+    overflow: "visible",
+    transition: "color 0.3s linear",
+    "& svg": {
+        fontSize: 16,
+        width: 16,
+        height: 16,
+    },
+    [theme.breakpoints.up(960)]: {
         minWidth: 0,
-        flexDirection: "row",
-        letterSpacing: "1px",
-        justifyContent: "center",
-        gap: "0.5rem",
-        textTransform: "uppercase",
-        overflow: "visible",
-        transition: "color 0.3s linear",
+    },
+    [`& .${tabClasses.labelIcon}`]: {
+        minHeight: 53,
+    },
+    [`& .${tabClasses.icon}`]: {
+        marginBottom: 0,
+    },
+    [`&:hover`]: {
+        color: darken(theme.palette.secondary.main, 0.2),
+        transition: "color 1s linear, text-shadow 5s ease-in",
+        textShadow: `0 0 50px ${theme.palette.secondary.main}`,
+    },
+    [`&[data-status="active"]`]: {
+        color: theme.palette.secondary.main,
+    },
+
+    //Mobile styles
+    [theme.breakpoints.down("laptop")]: {
+        marginTop: 0,
+        height: NAVBAR_HEIGHT.mobile,
+        display: "flex",
+        flexDirection: "column",
+
         "& svg": {
             fontSize: 16,
-            width: 16,
-            height: 16,
+            width: theme.iconSize.lg,
+            height: theme.iconSize.lg,
         },
-        [theme.breakpoints.up(960)]: {
-            minWidth: 0,
-        },
-        [`& .${tabClasses.labelIcon}`]: {
-            minHeight: 53,
-        },
-        [`& .${tabClasses.icon}`]: {
-            marginBottom: 0,
-        },
-        [`&:hover`]: {
-            color: darken(theme.palette.secondary.main, 0.2),
-            transition: "color 1s linear, text-shadow 5s ease-in",
-            textShadow: `0 0 50px ${theme.palette.secondary.main}`,
-        },
-        [`&[data-status="active"]`]: {
-            color: theme.palette.secondary.main,
-        },
-    }))
-);
+    },
+}));
 
 const TabLabel = styled(Typography)(({ theme }) => ({
     marginLeft: 8,
     lineHeight: "12px",
-    [theme.breakpoints.down(960)]: {
+    [theme.breakpoints.down("laptop")]: {
         marginLeft: 0,
-        display: "none",
+        fontSize: theme.typography.caption.fontSize,
+        lineHeight: "inherit",
+        textAlign: "center",
+        width: "100%",
     },
 }));
 
@@ -94,40 +163,9 @@ function NavTabs() {
     };
 
     return (
-        <Tabs
+        <StyledTabs
             ref={ref}
             value={currentIdx === -1 ? false : currentIdx}
-            sx={(theme) => ({
-                color: "inherit",
-                overflow: "hidden",
-                display: "flex",
-                width: "100%",
-                justifyContent: "center",
-                [`& .${tabsClasses.indicator}`]: {
-                    position: "absolute",
-                    top: `calc(50% - 8px)`,
-                    height: "16px",
-                    filter: "blur(50px)",
-                    backgroundColor: theme.palette.secondary.main,
-                    zIndex: -1,
-                },
-                [`& .MuiTabs-scroller`]: {
-                    width: "100%",
-                    overflow: "visible",
-                },
-                // Spacing of tabs for different breakpoints
-                [`& .MuiTabs-flexContainer`]: {
-                    width: "100%",
-                    gap: "4px",
-                    justifyContent: "center",
-                    [theme.breakpoints.up("laptop")]: {
-                        gap: "30px",
-                    },
-                },
-                [`&:hover .mouse-trail`]: {
-                    opacity: 1,
-                },
-            })}
             onMouseMove={handleMouseMove}
         >
             {navItems.map((item) => (
@@ -135,11 +173,15 @@ function NavTabs() {
             ))}
             {/* Mouse hover effect */}
             <MouseTrail />
-        </Tabs>
+        </StyledTabs>
     );
 }
 
-/** Sticky top navbar */
+/** Navbar component
+ *
+ * on desktop: fixed to the top
+ * on mobile: fixed to the bottom
+ */
 export default function NavBar() {
     return (
         <Box
@@ -148,16 +190,18 @@ export default function NavBar() {
                 bottom: 0,
                 zIndex: 10,
                 width: "100dvw",
-                height: "48px",
+                height: NAVBAR_HEIGHT.mobile,
                 display: "flex",
                 justifyContent: "center",
                 alignItems: "flex-start",
-                borderBottom: "1px solid",
-                borderColor: "divider",
                 backdropFilter: "blur(25px)",
                 //backgroundColor: "#21252933",
+
                 [theme.breakpoints.up("laptop")]: {
                     top: 0,
+                    borderBottom: "1px solid",
+                    borderColor: "divider",
+                    height: NAVBAR_HEIGHT.desktop,
                 },
             })}
         >

--- a/frontend/src/components/frontpage/navbar.tsx
+++ b/frontend/src/components/frontpage/navbar.tsx
@@ -57,6 +57,7 @@ const StyledTabs = styled(Tabs)(({ theme }) => ({
             justifyContent: "center",
             alignItems: "center",
         },
+        background: "linear-gradient(to bottom, transparent, black)",
     },
 }));
 

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -5,7 +5,7 @@ import { HeadContent } from "@tanstack/react-router";
 import { createRootRouteWithContext, Outlet } from "@tanstack/react-router";
 
 import { PageWrapper } from "@/components/common/page";
-import NavBar from "@/components/frontpage/navbar";
+import NavBar, { NAVBAR_HEIGHT } from "@/components/frontpage/navbar";
 import { TerminalContextProvider } from "@/components/frontpage/terminal";
 import {
     AudioContextProvider,
@@ -54,18 +54,14 @@ function RootComponent() {
                     sx={(theme) => ({
                         flexGrow: 1,
                         [theme.breakpoints.up("laptop")]: {
-                            paddingTop: "48px", // Navbar
+                            paddingTop: NAVBAR_HEIGHT.desktop,
                         },
                         [theme.breakpoints.down("laptop")]: {
                             position: "fixed",
-                            bottom: "48px", // Navbar height
-                            height: "calc(100dvh - 48px)", // Navbar height
+                            height: "100dvh",
                         },
                         width: "100%",
                         height: "100%",
-
-                        // if we want to move Navbar bottom
-                        // marginTop: { xs: 0, md: "64px" },
                         overflow: "auto",
                         display: "flex",
                         flexDirection: "column",
@@ -74,9 +70,22 @@ function RootComponent() {
                 >
                     <TerminalContextProvider>
                         <AudioContextProvider>
-                            {/* A bit messy but needed for the audio player scroll */}
-                            <Box sx={{ height: "100%", overflow: "hidden" }}>
-                                <Box sx={{ height: "100%", overflow: "auto" }}>
+                            {/* A bit messy but needed for translucent navbar effect on mobile */}
+                            <Box
+                                sx={{
+                                    height: "100%",
+                                    overflow: "visible",
+                                }}
+                            >
+                                <Box
+                                    sx={(theme) => ({
+                                        height: "100%",
+                                        overflow: "auto",
+                                        [theme.breakpoints.down("laptop")]: {
+                                            paddingBottom: NAVBAR_HEIGHT.mobile,
+                                        },
+                                    })}
+                                >
                                     <Outlet />
                                 </Box>
                                 <LazyAudioPlayer />


### PR DESCRIPTION
We talked about that some time ago. I managed to make the translucent bottom bar styling happen.

Also restyled the mobile bottom bar slightly:
- it is a bit bigger 
- it now includes labels for the different item

[translu_bot.webm](https://github.com/user-attachments/assets/9d84e85b-4ad6-4428-a4e3-72abc228fb03)
