### PR TITLE
Fixed cache invalidation for folder deletion

### DIFF
--- a/.github/workflows/changelog_reminder.yml
+++ b/.github/workflows/changelog_reminder.yml
@@ -1,0 +1,35 @@
+name: Verify changelog updated
+
+on:
+    pull_request_target:
+        types:
+            - opened
+            - ready_for_review
+
+jobs:
+    check_changes:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Get all updated Python files
+              id: changed-files
+              uses: tj-actions/changed-files@v46
+              with:
+                  files: |
+                      **.py
+                      **.ts
+                      **.tsx
+
+            - name: Check for the changelog update
+              id: changelog-update
+              uses: tj-actions/changed-files@v46
+              with:
+                  files: CHANGELOG.md
+
+            - name: Comment under the PR with a reminder
+              if: steps.changed-files.outputs.any_changed == 'true' && steps.changelog-update.outputs.any_changed == 'false'
+              uses: thollander/actions-comment-pull-request@v2
+              with:
+                  message: "Thank you for the PR! The changelog has not been updated, so here is a friendly reminder to check if you need to add an entry."
+                  GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - Upcoming
+
+### Fixed
+
+- Cache invalidation now triggers on delete folder in frontend [#138](https://github.com/pSpitzner/beets-flask/issues/138)
+
 ## [1.0.0] - 25-07-06
 
 This is a breaking change, you will need to update your configs and delete your beets-flask

--- a/backend/beets_flask/server/routes/inbox.py
+++ b/backend/beets_flask/server/routes/inbox.py
@@ -12,14 +12,16 @@ from tinytag import TinyTag
 
 from beets_flask.database import db_session_factory
 from beets_flask.database.models.states import FolderInDb, SessionStateInDb
-from beets_flask.disk import Folder, dir_files, dir_size, log, path_to_folder
+from beets_flask.disk import Folder, dir_files, dir_size, path_to_folder
 from beets_flask.importer.progress import Progress
 from beets_flask.server.exceptions import InvalidUsageException, NotFoundException
 from beets_flask.server.routes.library.artwork import send_image
 from beets_flask.server.utility import (
     pop_folder_params,
     pop_paths_param,
-    pop_query_param,
+)
+from beets_flask.server.websocket.status import (
+    trigger_clear_cache,
 )
 from beets_flask.watchdog.inbox import (
     get_inbox_folders,
@@ -124,7 +126,7 @@ async def get_folder():
 @inbox_bp.route("/tree/refresh", methods=["POST"])
 async def refresh_cache():
     """Clear the cache for the path_to_dict function."""
-    path_to_folder.cache.clear()  # type: ignore
+    await trigger_clear_cache()
     return "Ok"
 
 
@@ -171,7 +173,7 @@ async def delete():
         shutil.rmtree(f.full_path)
 
     # Clear the cache for the deleted folders
-    path_to_folder.cache.clear()  # type: ignore
+    await trigger_clear_cache()
 
     return jsonify(
         {

--- a/backend/beets_flask/server/websocket/status.py
+++ b/backend/beets_flask/server/websocket/status.py
@@ -133,6 +133,7 @@ async def trigger_clear_cache():
     # This is used to clear the cache when a folder is deleted.
     # We use the FileSystemUpdate event to trigger this.
     # This clears the cache in all workers and clients
+    clear_cache()
     await send_status_update(FileSystemUpdate())
 
 

--- a/backend/beets_flask/server/websocket/status.py
+++ b/backend/beets_flask/server/websocket/status.py
@@ -128,6 +128,14 @@ async def send_status_update(
     await client.disconnect()
 
 
+async def trigger_clear_cache():
+    """Trigger a cache clear via the status socket."""
+    # This is used to clear the cache when a folder is deleted.
+    # We use the FileSystemUpdate event to trigger this.
+    # This clears the cache in all workers and clients
+    await send_status_update(FileSystemUpdate())
+
+
 R = TypeVar("R")  # Return
 P = ParamSpec("P")  # Parameters
 

--- a/backend/tests/integration/test_flows.py
+++ b/backend/tests/integration/test_flows.py
@@ -16,8 +16,6 @@ from sqlalchemy import delete, func, select
 from sqlalchemy.orm import Session
 
 from beets_flask.database.models.states import (
-    CandidateState,
-    CandidateStateInDb,
     FolderInDb,
     SessionStateInDb,
 )
@@ -32,7 +30,7 @@ from beets_flask.invoker.enqueue import (
     run_preview,
     run_preview_add_candidates,
 )
-from beets_flask.server.websocket.status import FolderStatusUpdate, JobStatusUpdate
+from beets_flask.server.websocket.status import FolderStatusUpdate
 from tests.mixins.database import IsolatedBeetsLibraryMixin, IsolatedDBMixin
 from tests.unit.test_importer.conftest import (
     VALID_PATHS,
@@ -41,14 +39,14 @@ from tests.unit.test_importer.conftest import (
 )
 
 
-class InvokerStatusMockMixin(ABC):
+class SendStatusMockMixin(ABC):
     """
     Allows to test without a running websocket server for
     status updates in the invoker.
 
     Usage:
     ```
-    class TestMyFeature(InvokerStatusMockMixin):
+    class TestMyFeature(SendStatusMockMixin):
         def test_something(self):
             # add to clean db
             assert self.statuses == [SomeStatus]
@@ -80,7 +78,7 @@ class InvokerStatusMockMixin(ABC):
         self.statuses = []
 
 
-class TestPreview(InvokerStatusMockMixin, IsolatedDBMixin, IsolatedBeetsLibraryMixin):
+class TestPreview(SendStatusMockMixin, IsolatedDBMixin, IsolatedBeetsLibraryMixin):
     """Test generating previews.
 
     - should add candidates
@@ -209,9 +207,7 @@ class TestPreview(InvokerStatusMockMixin, IsolatedDBMixin, IsolatedBeetsLibraryM
                 )
 
 
-class TestImportBest(
-    InvokerStatusMockMixin, IsolatedDBMixin, IsolatedBeetsLibraryMixin
-):
+class TestImportBest(SendStatusMockMixin, IsolatedDBMixin, IsolatedBeetsLibraryMixin):
     """Test a typical import using the best candidate.
 
     This should be the most common case, i.e. the candidate looks good!
@@ -607,9 +603,7 @@ class TestImportBest(
         assert exc["type"] == "IntegrityException"
 
 
-class TestImportAuto(
-    InvokerStatusMockMixin, IsolatedDBMixin, IsolatedBeetsLibraryMixin
-):
+class TestImportAuto(SendStatusMockMixin, IsolatedDBMixin, IsolatedBeetsLibraryMixin):
     """Test that the preview + threshold-dependent import works.
 
     The flow is as follows:
@@ -668,7 +662,7 @@ class TestImportAuto(
 
 
 class TestChooseCandidatesSingleTask(
-    InvokerStatusMockMixin, IsolatedDBMixin, IsolatedBeetsLibraryMixin
+    SendStatusMockMixin, IsolatedDBMixin, IsolatedBeetsLibraryMixin
 ):
     """Test a typical import using a choosen candidate."""
 
@@ -730,7 +724,7 @@ class TestChooseCandidatesSingleTask(
 
 
 class TestMultipleTasks(
-    InvokerStatusMockMixin, IsolatedDBMixin, IsolatedBeetsLibraryMixin
+    SendStatusMockMixin, IsolatedDBMixin, IsolatedBeetsLibraryMixin
 ):
     """Test a typical import of a multiple tasks using choosen candidates."""
 
@@ -841,9 +835,7 @@ class TestMultipleTasks(
         assert exc is None, "Should not return an error"
 
 
-class TestImportAsis(
-    InvokerStatusMockMixin, IsolatedDBMixin, IsolatedBeetsLibraryMixin
-):
+class TestImportAsis(SendStatusMockMixin, IsolatedDBMixin, IsolatedBeetsLibraryMixin):
     """Test a typical import using the asis candidate.
 
     We have an extra test for this as the asis candidate is a bit special,
@@ -863,7 +855,7 @@ class TestImportAsis(
 
 
 class TestImportCandidate(
-    InvokerStatusMockMixin, IsolatedDBMixin, IsolatedBeetsLibraryMixin
+    SendStatusMockMixin, IsolatedDBMixin, IsolatedBeetsLibraryMixin
 ):
     """Test a typical import using the specific candidate.
 

--- a/backend/tests/integration/test_routes/test_inbox.py
+++ b/backend/tests/integration/test_routes/test_inbox.py
@@ -6,8 +6,10 @@ import pytest
 
 from beets_flask.disk import Folder
 
+from ..test_flows import SendStatusMockMixin
 
-class TestDeleteEndpoint:
+
+class TestDeleteEndpoint(SendStatusMockMixin):
     tmp_path: Path
 
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
Seems like we forgot to trigger cache invalidation on each worker on folder delete from the frontend.

- added a function that can be called to trigger a cache invalidation on all workers

Also added a workflow to remind us to create changelog entries. Mostly copied from beets.

Should fix a part of #138