### PR TITLE
Added route to delete db model resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configuration option for artist separator characters `gui.library.artist_separator`
 - Docs subpage for configuration (including content)
 - `typing_extensions` is now a dependency, to allow for more typing features
+- The model api routes now allows for `DELETE` requests to delete resources by id. Not used yet but will be helpful for future features.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Configuration option for artist separator characters `gui.library.artist_separator`
 - Docs subpage for configuration (including content)
+- `typing_extensions` is now a dependency, to allow for more typing features
 
 ### Fixed
 

--- a/backend/beets_flask/server/routes/db_models/base.py
+++ b/backend/beets_flask/server/routes/db_models/base.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, Generic, Sequence, TypeVar
+from typing import Generic, Sequence, TypeVar
 
 from quart import Blueprint, request
 from sqlalchemy import select
@@ -42,6 +42,7 @@ class ModelAPIBlueprint(Generic[T]):
         """Register the routes for the blueprint."""
         self.blueprint.route("/", methods=["GET"])(self.get_all)
         self.blueprint.route("/id/<id>", methods=["GET"])(self.get_by_id)
+        self.blueprint.route("/id/<id>", methods=["DELETE"])(self.delete_by_id)
 
     async def get_all(self):
         params = dict(request.args)
@@ -78,6 +79,16 @@ class ModelAPIBlueprint(Generic[T]):
                 )
 
             return item.to_dict()
+
+    async def delete_by_id(self, id: str):
+        with db_session_factory() as session:
+            item = self.model.get_by(self.model.id == id, session=session)
+            if not item:
+                return {"message": f"Item with id {id} not found"}, 200
+            session.delete(item)
+            session.commit()
+
+        return {"message": f"Item with id {id} deleted successfully"}, 200
 
 
 # ------------------------------- Local Utility ------------------------------ #

--- a/backend/beets_flask/server/utility.py
+++ b/backend/beets_flask/server/utility.py
@@ -1,5 +1,7 @@
 from pathlib import Path
-from typing import Callable, TypeVar, cast
+from typing import Callable, cast
+
+from typing_extensions import TypeVar
 
 from beets_flask.invoker.job import ExtraJobMeta
 from beets_flask.logger import log
@@ -9,8 +11,7 @@ from .exceptions import InvalidUsageException
 R = TypeVar("R")
 D = TypeVar(
     "D",
-    # Fixme: Add once we update to python 3.13
-    # default=None,
+    default=None,
 )
 
 
@@ -66,7 +67,7 @@ def pop_extra_meta(params: dict, n_jobs=1) -> list[ExtraJobMeta]:
         The request args.
     """
 
-    job_refs: list[str] = pop_query_param(
+    job_refs: list[str] | None = pop_query_param(
         params=params, key="job_frontend_refs", convert_func=list, default=None
     )
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "aiofiles",
     "numpy",
     "pandas",
+    "typing_extensions",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
The model api routes now allows for `DELETE` requests to delete resources by id. Not used yet but will be helpful for future features.
