### PR TITLE
Trigger cli_exit events after import.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cache invalidation now triggers on delete folder in frontend [#138](https://github.com/pSpitzner/beets-flask/issues/138)
 - In albums and items view the clicking on artists does not return any results if the contained a separator character (e.g. `&`) [#132](https://github.com/pSpitzner/beets-flask/issues/138)
 - Cleanup old actions.tsx file, which included old unused code [#134](https://github.com/pSpitzner/beets-flask/issues/134)
+- The `cli_exit` event is now triggered after the import task is finished. This adds compatibility with some plugins which expected this event to be triggered after the import task is done. [#154](https://github.com/pSpitzner/beets-flask/issues/154).
 
 ### Changed
 

--- a/backend/tests/mixins/plugins.py
+++ b/backend/tests/mixins/plugins.py
@@ -1,0 +1,39 @@
+from abc import ABC
+from unittest import mock
+
+import pytest
+from beets.plugins import send
+
+
+class PluginEventsMixin(ABC):
+    """
+    Allows to test events sent by plugins.
+    This mixin captures events sent by plugins during tests.
+
+    Usage:
+    ```
+    class TestMyPlugin(PluginEventsMixin):
+        def test_event(self):
+            self.send_event("my_event", data="test")
+            assert "my_event" in self.events
+    ```
+
+    """
+
+    events: list[str] = []
+
+    def send_event(self, event: str, **kwargs):
+        self.events.append(event)
+        return send(event, **kwargs)
+
+    @pytest.fixture(autouse=True, scope="function")
+    def mock_events(self):
+        """Mock the emit_status decorator"""
+
+        with mock.patch(
+            "beets.plugins.send",
+            self.send_event,
+        ):
+            yield
+
+        self.events = []


### PR DESCRIPTION
This PR adds support for the `cli_exit` event, which is now triggered after a successful import operation. This event wasn't previously triggered.

### Changes

* **Event Triggering**:
  The `cli_exit` event is now emitted after import and undo
* **Test Enhancements**:
  Introduced a lightweight test mixin to capture CLI events during test execution.
* **New Test Case**:
  Added a test to verify that the `cli_exit` event is triggered appropriately, including after imports and undos.


closes #154