### PR TITLE
Invalidate session cache on any status update.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed session invalidation on folder updates. This especially fixes an issues where the watchdog would not trigger a session invalidation when a folder was deleted or renamed. [#163](https://github.com/pSpitzner/beets-flask/issues/163)
+
 ## [1.1.0] - 25-07-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed session invalidation on folder updates. This especially fixes an issues where the watchdog would not trigger a session invalidation when a folder was deleted or renamed. [#163](https://github.com/pSpitzner/beets-flask/issues/163)
+- Session cache wasn't invalidated on all folder updates. This especially fixes an issues where the watchdog would not trigger a session invalidation when a folder was deleted or renamed. [#163](https://github.com/pSpitzner/beets-flask/issues/163)
 
 ## [1.1.0] - 25-07-29
 

--- a/frontend/src/components/common/websocket/status.tsx
+++ b/frontend/src/components/common/websocket/status.tsx
@@ -65,16 +65,9 @@ export function StatusContextProvider({
                 }
             );
 
-            if (
-                updateData.status == FolderStatus.IMPORTED ||
-                updateData.status == FolderStatus.PREVIEWED ||
-                updateData.status == FolderStatus.DELETED ||
-                updateData.status == FolderStatus.FAILED
-            ) {
-                invalidateSession(updateData.hash, updateData.path, false).catch(
-                    console.error
-                );
-            }
+            invalidateSession(updateData.hash, updateData.path, false).catch(
+                console.error
+            );
         }
 
         async function handleFileSystemUpdate(updateData: FileSystemUpdate) {

--- a/frontend/src/components/common/websocket/status.tsx
+++ b/frontend/src/components/common/websocket/status.tsx
@@ -14,7 +14,7 @@ import { type QueryClient } from "@tanstack/react-query";
 import { queryClient } from "@/api/common";
 import { invalidateSession, statusQueryOptions } from "@/api/session";
 import { StatusSocket } from "@/api/websocket";
-import { FileSystemUpdate, FolderStatus, FolderStatusUpdate } from "@/pythonTypes";
+import { FileSystemUpdate, FolderStatusUpdate } from "@/pythonTypes";
 
 import useSocket from "./useSocket";
 interface StatusContextI {


### PR DESCRIPTION
It seems like we did not invalidate the frontend session cache when a status update was send with a pending status.

closes #163