### PR TITLE
Update beets dependency to 2.3.1

### DIFF
--- a/backend/beets_flask/importer/stages.py
+++ b/backend/beets_flask/importer/stages.py
@@ -519,9 +519,9 @@ def manipulate_files(
             operation = MoveOperation.COPY
 
         task.manipulate_files(
+            session,
             operation,
-            write=session.config["write"],
-            session=session,
+            write=session.config["write"]
         )
 
     # Progress, cleanup, and event.

--- a/backend/beets_flask/importer/states.py
+++ b/backend/beets_flask/importer/states.py
@@ -688,9 +688,7 @@ class CandidateState(BaseState):
             List[str],
             get_config()["import"]["duplicate_keys"]["album"].as_str_seq() or [],
         )
-        dup_query = library.Album.all_fields_query(
-            {key: tmp_album.get(key) for key in keys}
-        )
+        dup_query = tmp_album.duplicates_query(keys)
 
         # Re-Importing: Don't count albums with the same files as duplicates.
         task_paths = {i.path for i in self.task_state.task.items if i}

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 dependencies = [
     "quart>=0.20.0",
     "confuse>=2.0.1",
-    "beets==2.2.0",
+    "beets==2.3.1",
     "sqlalchemy>=2.0.35",
     "rq>=2.0.0",
     "watchdog>=5.0.3",


### PR DESCRIPTION
As discussed in #187, this is a first shot at updating the beets version in the project.

Surprisingly, not many changes were needed to make the tests pass again.

I've also tested with the `docker-compose.dev.yaml` setup, with the auto-import workflow. Worked without errors for both an album that was successfully matched, as well as one that was not (below threshold) with the workflow of manually selecting a release and importing. Deletion of imported releases also still worked.
