### PR TITLE
Fixes around Candidate Search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Archive files can now be deleted [#217](https://github.com/pSpitzner/beets-flask/issues/217)
 - Import Bootleg Button now works as expected [#218](https://github.com/pSpitzner/beets-flask/issues/218)
 - Startup script was not executed correctly if placed in `/config/beets-flask/startup.sh` [#227](https://github.com/pSpitzner/beets-flask/pull/227)
+- Another state-related bug around Searching for Candidates [#225](https://github.com/pSpitzner/beets-flask/issues/225). We now no longer require a certaint type of state before allowing to add candidates.
 
 ### Added
 

--- a/backend/beets_flask/invoker/enqueue.py
+++ b/backend/beets_flask/invoker/enqueue.py
@@ -36,7 +36,6 @@ from beets_flask.importer.session import (
     UndoSession,
     delete_from_beets,
 )
-from beets_flask.importer.states import Progress
 from beets_flask.importer.types import DuplicateAction
 from beets_flask.logger import log
 from beets_flask.redis import import_queue, preview_queue
@@ -490,12 +489,6 @@ async def run_preview_add_candidates(
 
     with db_session_factory() as db_session:
         s_state_live = _get_live_state_by_folder(hash, path, db_session)
-
-        if s_state_live.progress != Progress.PREVIEW_COMPLETED:
-            raise InvalidUsageException(
-                f"Session state not in preview completed state for {hash=} "
-                + f"Found state: {s_state_live.progress}"
-            )
 
         a_session = AddCandidatesSession(
             s_state_live,

--- a/backend/tests/integration/test_flows.py
+++ b/backend/tests/integration/test_flows.py
@@ -20,14 +20,13 @@ from beets_flask.database.models.states import (
     SessionStateInDb,
 )
 from beets_flask.disk import Folder
-from beets_flask.importer.progress import FolderStatus
+from beets_flask.importer.progress import FolderStatus, Progress
 from beets_flask.importer.session import (
     CandidateChoice,
     TaskIdMappingArg,
 )
 from beets_flask.importer.types import DuplicateAction
 from beets_flask.invoker.enqueue import (
-    Progress,
     run_import_auto,
     run_import_bootleg,
     run_import_candidate,

--- a/backend/tests/integration/test_routes/test_exceptions.py
+++ b/backend/tests/integration/test_routes/test_exceptions.py
@@ -1,5 +1,3 @@
-
-
 class TestErrorHandling:
     """Tests our exception handling capabilities."""
 

--- a/backend/tests/unit/test_setup.py
+++ b/backend/tests/unit/test_setup.py
@@ -14,8 +14,6 @@ def test_log():
     assert log.name == "beets-flask"
 
 
-
-
 def test_config():
     """Test that config is correctly set up for testing."""
     import tempfile

--- a/frontend/src/components/common/chips.tsx
+++ b/frontend/src/components/common/chips.tsx
@@ -230,6 +230,8 @@ export function FolderStatusChip({
             status_name = "Failed";
             if (folderStatus.exc?.type === "NoCandidatesFoundException") {
                 status_name = "No Match";
+            } else if (folderStatus.exc?.type === "NotImportedException") {
+                status_name = "Threshold";
             }
             break;
         default:


### PR DESCRIPTION
Auto-Import Sessions now set their status to Preview completed when rejected by the
match threshold.

Added a finalize stage, to give custom sessions an easy way to run code at the very end - like status updates.
Changed the Match Threshold Chip label from "Failed" to "Threshold".

Closes #225