### PR TITLE
workaround for #243, libtmux needs escaping.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Upcoming
+## [1.2.1] - 25-12-28
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Upcoming
+
+### Fixed
+
+- Workaround for semicolon character not appearing in web terminal [#243](https://github.com/pSpitzner/beets-flask/issues/243)
+
 ## [1.2.0] - 25-12-17
 
 ### ⚠️ Important ⚠️
@@ -42,7 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ruff now had the UP checks enabled to enforce modern python syntax.
 - Unified coverart components in the frontend, we now use common styling for external and internal coverart.
 - Moved inbox metadata fetching into the library api routes.
-- Frontend formatter prettier is now enforced via a CI/CD workflow step 
+- Frontend formatter prettier is now enforced via a CI/CD workflow step
 
 ### Dependencies
 

--- a/backend/beets_flask/server/websocket/terminal.py
+++ b/backend/beets_flask/server/websocket/terminal.py
@@ -185,7 +185,7 @@ def _get_cursor_position():
 async def pty_input(sid, data):
     """Write to the child pty."""
     # log.debug(f"{sid} input {data}")
-    pane.send_keys(data["input"], enter=False)
+    pane.send_keys(data["input"].replace(";", "\\;"), enter=False, literal=True)
     # re-emitting continuously at high rate causes quite high cpu load, therefore we
     # only re-emit at low intervals, and everytime we _know_ something changed.
     await asyncio.gather(

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "beets-flask"
 description = "An opinionated web-interface around the music organizer [beets](https://beets.io/)"
-version = "1.2.0"
+version = "1.2.1"
 authors = [
     { name = "F. Paul Spitzner", email = "paul.spitzner@gmail.com" },
     { name = "Sebastian B. Mohr", email = "sebastian@mohrenclan.de" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "frontend",
     "private": true,
-    "version": "1.2.0",
+    "version": "1.2.1",
     "type": "module",
     "scripts": {
         "dev": "vite --host --cors",


### PR DESCRIPTION
we should really drop the keystroke parsing layer, now that we are async.

Closes #243 