### PR TITLE
Fix demo startup

### DIFF
--- a/backend/beets_flask/config/beets_config.py
+++ b/backend/beets_flask/config/beets_config.py
@@ -235,7 +235,13 @@ class BeetsFlaskConfig(ConfigExtra[BeetsSchema]):
                 "/music/beets_flask_config_example/inbox_auto",
                 "/music/beets_flask_config_example/inbox_preview",
             ]:
-                os.makedirs(dir, exist_ok=True)
+                try:
+                    os.makedirs(dir, exist_ok=True)
+                except OSError:
+                    log.info(
+                        "Could not create beets_flask_config_example directories, "
+                        + "likely because this was not run inside the docker container."
+                    )
 
     # ------------------------------ Utility getters ----------------------------- #
 

--- a/backend/beets_flask/config/config_b_example.yaml
+++ b/backend/beets_flask/config/config_b_example.yaml
@@ -27,14 +27,14 @@ plugins: [
         musicbrainz, # needs to be enabled explicitly since beets 2.4.0
     ]
 
-directory: /music/imported
+directory: /music/beets_flask_config_example/imported
 # library: /config/beets/library.db # default location in the container
 
 import:
     move: no
     copy: yes
     write: yes
-    log: /music/last_beets_imports.log
+    log: /music/beets_flask_config_example/last_beets_imports.log
     quiet_fallback: skip
     detail: yes
     duplicate_action: ask # ask|skip|merge|keep|remove

--- a/backend/beets_flask/config/config_bf_example.yaml
+++ b/backend/beets_flask/config/config_bf_example.yaml
@@ -26,12 +26,12 @@ gui:
 
             Inbox1:
                 name: "Dummy inbox"
-                path: "/music/dummy"
+                path: "/music/beets_flask_config_example/inbox_off"
                 autotag: "off"
                 # do not automatically trigger tagging and do not automatically import
             Inbox2:
                 name: "Auto Inbox"
-                path: "/music/inbox_auto"
+                path: "/music/beets_flask_config_example/inbox_auto"
                 autotag: "auto"
                 # trigger tag and import if a good match is found based on `auto_threshold`
                 auto_threshold: null
@@ -40,6 +40,6 @@ gui:
                 # matches with 90% similarity or better.
             Inbox3:
                 name: "An Inbox that only generates the previews"
-                path: "/music/inbox_preview"
+                path: "/music/beets_flask_config_example/inbox_preview"
                 autotag: "preview"
                 # trigger tag but do not import, recommended for most control

--- a/backend/beets_flask/config/schema.py
+++ b/backend/beets_flask/config/schema.py
@@ -95,7 +95,7 @@ class InboxSectionSchema:
         default_factory=lambda: {
             "placeholder": InboxFolderSchema(
                 name="Please check your config!",
-                path="/music/inbox",
+                path="/music/beets_flask_config_example/inbox_placeholder",
                 autotag="off",
             )
         }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -96,8 +96,12 @@ RUN mkdir -p /config/beets /config/beets-flask /logs && \
     chown -R beetle:beetle /config /logs
 
 # our default folders they should not be used in production
-RUN mkdir -p /music/inbox /music/imported && \
-    chown -R beetle:beetle /music
+RUN mkdir -p \
+    /music/beets_flask_config_example/imported \
+    /music/beets_flask_config_example/inbox_off \
+    /music/beets_flask_config_example/inbox_auto \
+    /music/beets_flask_config_example/inbox_preview
+RUN chown -R beetle:beetle /music
 
 # Install dependencies:
 RUN --mount=type=cache,sharing=locked,target=/var/cache/apt \


### PR DESCRIPTION
Reworked folder structure around the default config.

Now, we dont get non-functional inboxes on first startup.
Two cases covered:
- no volume mounts into container (folders are already created in base image)
- volume mounts (user mounted to /music, -> folders are also created if we placed our demo configs)