### PR TITLE
make redis server connection configurable through $REDIS_URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upload Files via the WebUI. You can now drag-and-drop single files into an inbox. To upload whole albums, zip them on your host first (uploading of folders directly is not implemented, as it would require a secure context).
 - New config option `gui.terminal.enabled` (default: true) [#254](https://github.com/pSpitzner/beets-flask/pull/224)
 - You can now alternatively use `PUID` and `PGID` instead of `GROUP_ID` and `USER_ID` environment variables. Good for [yaml anchors](https://docs.docker.com/reference/compose-file/fragments/). [#260](https://github.com/pSpitzner/beets-flask/issues/260)
+- Use an external redis server by setting the `REDIS_URL` environment variable. [#277](https://github.com/pSpitzner/beets-flask/pull/277)
 
 ### Fixed
 - Missing library stats dont cause a crash on first launch anymore [#264](https://github.com/pSpitzner/beets-flask/issues/264)

--- a/backend/beets_flask/redis.py
+++ b/backend/beets_flask/redis.py
@@ -1,13 +1,17 @@
 import asyncio
+import os
 import time
 from concurrent.futures import ThreadPoolExecutor
 
-from redis import Redis
+import redis
 from rq import Queue
 from rq.job import Job
 
 # Setup redis connection
-redis_conn = Redis()
+if os.environ.get("REDIS_URL"):
+    redis_conn = redis.from_url(os.environ["REDIS_URL"])
+else:
+    redis_conn = redis.Redis()
 
 # Init our different queues
 preview_queue = Queue("preview", connection=redis_conn, default_timeout=600)

--- a/docker/entrypoints/entrypoint.sh
+++ b/docker/entrypoints/entrypoint.sh
@@ -21,7 +21,9 @@ export PYTHONWARNINGS="ignore"
 # running the server from inside the backend dir makes imports and redis easier
 cd /repo/backend
 
-redis-server --daemonize yes >/dev/null 2>&1
+if [ -z "$REDIS_URL" ]; then
+  redis-server --daemonize yes >/dev/null 2>&1
+fi
 
 # blocking
 python ./launch_db_init.py

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -256,7 +256,7 @@ services:
         ...
         environment:
             ...
-            REDIS_URL: "http://redis:3000/"
+            REDIS_URL: "redis://redis:6379/"
 volumes:
     redis:
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -240,6 +240,26 @@ Default: `/config/beets-flask`
 
 Should not be changed.
 
+### `REDIS_URL`
+
+Usually, a daemonised Redis server is started within the container. This can cause issues due to the expectation that only one process runs per container, or if you wish to run the beets-flask container with a read-only root filesystem, or want greater control over the persistence of the Redis database. The `REDIS_URL` environment variable makes beets-flask connect to an external Redis instead, ideally one running in another container.
+
+Example: Add a Redis container to your `docker-compose.yaml`, and make beets-flask connect to it:
+
+```yaml
+services:
+    redis:
+        image: docker.io/library/redis:alpine
+        volumes:
+            - redis:/data
+    beets-flask:
+        ...
+        environment:
+            ...
+            REDIS_URL: "http://redis:3000/"
+volumes:
+    redis:
+```
 
 ## Validation
 


### PR DESCRIPTION
So that a Redis instance outside of the container may be used, read the `REDIS_URL` environment variable. If it is set and non-empty, assume it is a `redis://` protocol URL and connect to that instead of forking a Redis instance inside the container. This allows the well understood behaviour of a dedicated Redis image, or a Redis running outside a container, to be used, including more flexible logging and control over configuration.