### PR TITLE
Changed heuristic for archive checks to only use file extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Missing library stats dont cause a crash on first launch anymore [#264](https://github.com/pSpitzner/beets-flask/issues/264)
+- Fixed a potential memory leak when checking if files are archives. We now only check the file extension instead of trying to open the file, which should avoid the issue with `tarfile.is_tarfile` [#258](https://github.com/pSpitzner/beets-flask/issues/258)
 
 ### Other (dev)
 

--- a/backend/beets_flask/disk.py
+++ b/backend/beets_flask/disk.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from functools import cache
+import importlib.util
 import os
 import re
 import subprocess
@@ -8,14 +8,12 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
 from fnmatch import fnmatch
+from functools import cache
 from pathlib import Path
 from typing import (
     Literal,
 )
 
-from beets.importer import (
-    ArchiveImportTask,
-)
 from beets.importer.tasks import (
     MULTIDISC_MARKERS,
     MULTIDISC_PAT_FMT,
@@ -229,19 +227,10 @@ def allowed_archive_extensions() -> list[str]:
     ext = [".tar", ".tar.gz", ".tgz", ".tar.bz2", ".tbz2", ".tar.xz", ".txz"]
     # Zip files
     ext += [".zip"]
-    try:
-        from rarfile import RarFile
-
+    if importlib.util.find_spec("rarfile") is not None:
         ext += [".rar"]
-    except ImportError:
-        pass
-
-    try:
-        from py7zr import SevenZipFile
-
+    if importlib.util.find_spec("py7zr") is not None:
         ext += [".7z"]
-    except ImportError:
-        pass
     return ext
 
 

--- a/backend/beets_flask/disk.py
+++ b/backend/beets_flask/disk.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from functools import cache
 import os
 import re
 import subprocess
@@ -222,9 +223,37 @@ class Archive(FileSystemItem):
         )
 
 
+@cache
+def allowed_archive_extensions() -> list[str]:
+    # Tar files
+    ext = [".tar", ".tar.gz", ".tgz", ".tar.bz2", ".tbz2", ".tar.xz", ".txz"]
+    # Zip files
+    ext += [".zip"]
+    try:
+        from rarfile import RarFile
+
+        ext += [".rar"]
+    except ImportError:
+        pass
+
+    try:
+        from py7zr import SevenZipFile
+
+        ext += [".7z"]
+    except ImportError:
+        pass
+    return ext
+
+
 def is_archive_file(path: Path | str) -> bool:
-    """Check if a file is an archive file based on its extension."""
-    return ArchiveImportTask.is_archive(str(path))
+    """Check if a file is an archive file based on its extension.
+
+    It seems like there is a memory issue with `tarfile.is_tarfile`
+    (see https://github.com/pSpitzner/beets-flask/issues/258). We try
+    to avoid this by only checking the file extension here, and not trying to open the file.
+    """
+    allowed_extensions = allowed_archive_extensions()
+    return Path(path).suffix.lower() in allowed_extensions
 
 
 @dataclass

--- a/docs/develop/contribution.md
+++ b/docs/develop/contribution.md
@@ -68,8 +68,8 @@ Run [Ruff](https://docs.astral.sh/ruff/) manually or use the pre-commit hooks to
 ```bash
 cd backend
 # Code formatting and linting
-ruff check
-ruff lint
+ruff check . --fix
+ruff format .
 # Typing checks
 mypy .
 # Run the tests


### PR DESCRIPTION
Changed heuristic for archive checks to only use file
extensions. This is done to prevent unpacking archived files prematurely.

closes #258