### PR TITLE
Store config loading errors for upstream handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Config validation (when loading config files):
-  - Yaml syntax and parser errors are passed to the frontend for user examination instead of crashing before UI startup [#305](https://github.com/pSpitzner/beets-flask/pull/305)
-  - We now check that specified options will work. If not, the frontend will show an error message with details on what's wrong. This applies to `gui` settings (i.e. our own ones, `beets-flask/config.yaml`) and very select ones from native beets (only those which we use directly). Hopefully, this will eventually cover all config options of beets native, but this is more of an upsream task. [#224](https://github.com/pSpitzner/beets-flask/pull/224).
+- Config validation. When loading config files we now check that specified options will work. If not, the frontend will show an error message with details on what's wrong. This applies to `gui` settings (i.e. our own ones, `beets-flask/config.yaml`) and very select ones from native beets (only those which we use directly). Hopefully, this will eventually cover all config options of beets native, but this is more of an upsream task. [#224](https://github.com/pSpitzner/beets-flask/pull/224).
 - Upload Files via the WebUI. You can now drag-and-drop single files into an inbox. To upload whole albums, zip them on your host first (uploading of folders directly is not implemented, as it would require a secure context).
 - New config option `gui.terminal.enabled` (default: true) [#254](https://github.com/pSpitzner/beets-flask/pull/224)
 - You can now alternatively use `PUID` and `PGID` instead of `GROUP_ID` and `USER_ID` environment variables. Good for [yaml anchors](https://docs.docker.com/reference/compose-file/fragments/). [#260](https://github.com/pSpitzner/beets-flask/issues/260)
@@ -35,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a potential memory leak when checking if files are archives. We now only check the file extension instead of trying to open the file, which should avoid the issue with `tarfile.is_tarfile` [#258](https://github.com/pSpitzner/beets-flask/issues/258)
 - Fixed tmux terminal could not start in some environments if `SHELL` was not set currently. We now always start a bash shell [#282](https://github.com/pSpitzner/beets-flask/issues/282)
 - Container user `beetle` now uses bash terminal by default and activates the uv environment automatically.
+- Yaml syntax and parser errors are passed to the frontend for user examination instead of crashing before UI startup [#305](https://github.com/pSpitzner/beets-flask/pull/305)
 
 
 ### Other (dev)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Config validation. When loading config files we now check that specified options will work. If not, the frontend will show an error message with details on what's wrong. This applies to `gui` settings (i.e. our own ones, `beets-flask/config.yaml`) and very select ones from native beets (only those which we use directly). Hopefully, this will eventually cover all config options of beets native, but this is more of an upsream task. [#224](https://github.com/pSpitzner/beets-flask/pull/224).
+- Config validation (when loading config files):
+  - Yaml syntax and parser errors are passed to the frontend for user examination instead of crashing before UI startup [#305](https://github.com/pSpitzner/beets-flask/pull/305)
+  - We now check that specified options will work. If not, the frontend will show an error message with details on what's wrong. This applies to `gui` settings (i.e. our own ones, `beets-flask/config.yaml`) and very select ones from native beets (only those which we use directly). Hopefully, this will eventually cover all config options of beets native, but this is more of an upsream task. [#224](https://github.com/pSpitzner/beets-flask/pull/224).
 - Upload Files via the WebUI. You can now drag-and-drop single files into an inbox. To upload whole albums, zip them on your host first (uploading of folders directly is not implemented, as it would require a secure context).
 - New config option `gui.terminal.enabled` (default: true) [#254](https://github.com/pSpitzner/beets-flask/pull/224)
 - You can now alternatively use `PUID` and `PGID` instead of `GROUP_ID` and `USER_ID` environment variables. Good for [yaml anchors](https://docs.docker.com/reference/compose-file/fragments/). [#260](https://github.com/pSpitzner/beets-flask/issues/260)

--- a/backend/beets_flask/config/beets_config.py
+++ b/backend/beets_flask/config/beets_config.py
@@ -31,7 +31,7 @@ class BeetsFlaskConfig(ConfigExtra[BeetsSchema]):
     def __init__(self):
         """Initialize the config object with the default values."""
         super().__init__(schema=BeetsSchema, data=BeetsSchema())
-        self._config_errors = None
+        self._config_errors: list[ConfigurationError] = []
         BeetsFlaskConfig.write_examples_as_user_defaults()
         self.reload()
         self.commit_to_beets()
@@ -62,7 +62,7 @@ class BeetsFlaskConfig(ConfigExtra[BeetsSchema]):
         """
         log.debug("Resetting/Reloading config")
         super().reset()
-        self._config_errors: list[ConfigurationError] = []
+        self._config_errors = []
 
         # Config sources:
         # 1. beets defaults

--- a/backend/beets_flask/config/beets_config.py
+++ b/backend/beets_flask/config/beets_config.py
@@ -4,7 +4,7 @@ import os
 import shutil
 import sys
 from pathlib import Path
-from typing import Literal, Self, cast
+from typing import Any, Literal, Self, cast
 
 import beets
 import yaml
@@ -31,7 +31,6 @@ class BeetsFlaskConfig(ConfigExtra[BeetsSchema]):
     def __init__(self):
         """Initialize the config object with the default values."""
         super().__init__(schema=BeetsSchema, data=BeetsSchema())
-        self._config_errors: list[ConfigurationError] = []
         BeetsFlaskConfig.write_examples_as_user_defaults()
         self.reload()
         self.commit_to_beets()
@@ -50,6 +49,15 @@ class BeetsFlaskConfig(ConfigExtra[BeetsSchema]):
         beets_folder = os.getenv("BEETSDIR", os.path.expanduser("~/.config/beets"))
         return Path(beets_folder) / "config.yaml"
 
+    @staticmethod
+    def load_yaml(path: str | Path) -> dict[str, Any]:
+        """Try to load a yaml and reraise errors as configuration errors."""
+        try:
+            with open(path) as f:
+                return yaml.safe_load(f)
+        except (ScannerError, YAMLError) as e:
+            raise ConfigurationError(message=str(e))
+
     def reload(self, extra_yaml_path: str | Path | None = None) -> Self:
         """Reload the config.
 
@@ -62,7 +70,6 @@ class BeetsFlaskConfig(ConfigExtra[BeetsSchema]):
         """
         log.debug("Resetting/Reloading config")
         super().reset()
-        self._config_errors = []
 
         # Config sources:
         # 1. beets defaults
@@ -71,58 +78,20 @@ class BeetsFlaskConfig(ConfigExtra[BeetsSchema]):
         # But: we want to encourage user to add fields that are accessed
         # from _our_ config into the schema.
         # Thus only porting requirement: copy the relevant beets default into the schema
-        #
-        # 2. beets user config
-        # 3. beets-flask user config
+        # 2. beets-flask user config
+        # 3. extra config
 
-        for label, path_fn in [
-            ("beets", self.get_beets_config_path),
-            ("beets-flask", self.get_beets_flask_config_path),
-        ]:
-            path = path_fn()
-            if not path.exists():
-                continue
-            try:
-                with open(path) as f:
-                    loaded = yaml.safe_load(f)
-                if not isinstance(loaded, dict):
-                    raise yaml.YAMLError("Config is not a YAML dictionary.")
-                self.update(loaded)
-            except ScannerError as e:
-                message = str(e)
-                # handle using beets template function identifier as the first character
-                if "'%' that cannot start any token" in str(e):
-                    message += "\nTo use the template function you should surround the content with quotes"
-                    log.error(
-                        f"Unquoted template function starting value in {label} config at {path}: {e}"
-                    )
-                else:
-                    log.error(f"Failed to parse {label} config at {path}: {e}")
-                self._config_errors.append(
-                    ConfigurationError(message=message, section=f"{path}")
-                )
-            except YAMLError as e:
-                print(e.__class__)
-                log.error(f"Failed to parse {label} config at {path}: {e}")
-                self._config_errors.append(
-                    ConfigurationError(message=str(e), section=f"{path}")
-                )
-
-        # extra
+        sources: list[Path] = [
+            self.get_beets_config_path(),
+            self.get_beets_flask_config_path(),
+        ]
         if extra_yaml_path is not None:
-            # Dev/test — still raise immediately so CI catches it
-            with open(extra_yaml_path) as f:
-                loaded = yaml.safe_load(f)
-            if not isinstance(loaded, dict):
-                raise ValueError("Extra config is not a valid YAML dictionary.")
-            self.update(loaded)
+            sources.append(Path(extra_yaml_path))
 
-        try:
-            self.validate()
-        except MultiConfigurationError as e:
-            self._config_errors.extend(e.errors)
-        except ConfigurationError as e:
-            self._config_errors.append(e)
+        for path in sources:
+            if path.exists():
+                # EYConfs update method also validates against the schema
+                self.update(self.load_yaml(path))
 
         return self
 
@@ -306,14 +275,6 @@ class BeetsFlaskConfig(ConfigExtra[BeetsSchema]):
         if gui_globs is None or gui_globs == "_use_beets_ignore":
             gui_globs = self.data.ignore
         return cast(list[str], gui_globs)
-
-    @property
-    def errors(self) -> list[ConfigurationError]:
-        return getattr(self, "_config_errors", [])
-
-    @property
-    def is_healthy(self) -> bool:
-        return len(self.errors) == 0
 
 
 config: BeetsFlaskConfig | None = None

--- a/backend/beets_flask/config/beets_config.py
+++ b/backend/beets_flask/config/beets_config.py
@@ -13,6 +13,8 @@ from beets.plugins import get_plugin_names, load_plugins
 from eyconf import ConfigExtra
 from eyconf.asdict import asdict_with_aliases
 from eyconf.validation import ConfigurationError, MultiConfigurationError
+from yaml import YAMLError
+from yaml.scanner import ScannerError
 
 from beets_flask.logger import log
 from beets_flask.utility import deprecation_warning
@@ -86,7 +88,21 @@ class BeetsFlaskConfig(ConfigExtra[BeetsSchema]):
                 if not isinstance(loaded, dict):
                     raise yaml.YAMLError("Config is not a YAML dictionary.")
                 self.update(loaded)
-            except yaml.YAMLError as e:
+            except ScannerError as e:
+                message = str(e)
+                # handle using beets template function identifier as the first character
+                if "'%' that cannot start any token" in str(e):
+                    message += "\nTo use the template function you should surround the content with quotes"
+                    log.error(
+                        f"Unquoted template function starting value in {label} config at {path}: {e}"
+                    )
+                else:
+                    log.error(f"Failed to parse {label} config at {path}: {e}")
+                self._config_errors.append(
+                    ConfigurationError(message=message, section=f"{path}")
+                )
+            except YAMLError as e:
+                print(e.__class__)
                 log.error(f"Failed to parse {label} config at {path}: {e}")
                 self._config_errors.append(
                     ConfigurationError(message=str(e), section=f"{path}")

--- a/backend/beets_flask/config/beets_config.py
+++ b/backend/beets_flask/config/beets_config.py
@@ -29,6 +29,7 @@ class BeetsFlaskConfig(ConfigExtra[BeetsSchema]):
     def __init__(self):
         """Initialize the config object with the default values."""
         super().__init__(schema=BeetsSchema, data=BeetsSchema())
+        self._config_errors = None
         BeetsFlaskConfig.write_examples_as_user_defaults()
         self.reload()
         self.commit_to_beets()
@@ -48,53 +49,65 @@ class BeetsFlaskConfig(ConfigExtra[BeetsSchema]):
         return Path(beets_folder) / "config.yaml"
 
     def reload(self, extra_yaml_path: str | Path | None = None) -> Self:
-        """Reset the config to default values.
+        """Reload the config.
 
         This loads the user config from yaml files after resetting to defaults.
 
         The `extra_yaml_path` argument is mainly for testing purposes, to add a last
         yaml layer with high priority.
+
+        Any error messages (YAML parsing, validation) are stored for upstream handling
         """
         log.debug("Resetting/Reloading config")
         super().reset()
+        self._config_errors: list[ConfigurationError] = []
 
-        # There are 3 potential sources
-
+        # Config sources:
         # 1. beets defaults
-        # We do not load them into _out_ config.
+        # We do not load them into _our_ config.
         # They are still available in the beets_config property.
         # But: we want to encourage user to add fields that are accessed
         # from _our_ config into the schema.
         # Thus only porting requirement: copy the relevant beets default into the schema
-
+        #
         # 2. beets user config
-        if self.get_beets_config_path().exists():
-            with open(self.get_beets_config_path()) as f:
-                loaded = yaml.safe_load(f)
-                if not isinstance(loaded, dict):
-                    raise ValueError("Beets config is not a valid YAML dictionary.")
-                # EYConfs update method also validates against the schema
-                self.update(loaded)
-
         # 3. beets-flask user config
-        if self.get_beets_flask_config_path().exists():
-            with open(self.get_beets_flask_config_path()) as f:
-                loaded = yaml.safe_load(f)
+
+        for label, path_fn in [
+            ("beets", self.get_beets_config_path),
+            ("beets-flask", self.get_beets_flask_config_path),
+        ]:
+            path = path_fn()
+            if not path.exists():
+                continue
+            try:
+                with open(path) as f:
+                    loaded = yaml.safe_load(f)
                 if not isinstance(loaded, dict):
-                    raise ValueError(
-                        "Beets flask config is not a valid YAML dictionary."
-                    )
+                    raise yaml.YAMLError("Config is not a YAML dictionary.")
                 self.update(loaded)
+            except yaml.YAMLError as e:
+                log.error(f"Failed to parse {label} config at {path}: {e}")
+                self._config_errors.append(
+                    ConfigurationError(message=str(e), section=f"{path}")
+                )
 
         # extra
         if extra_yaml_path is not None:
+            # Dev/test — still raise immediately so CI catches it
             with open(extra_yaml_path) as f:
                 loaded = yaml.safe_load(f)
-                if not isinstance(loaded, dict):
-                    raise ValueError("Extra config is not a valid YAML dictionary.")
-                self.update(loaded)
+            if not isinstance(loaded, dict):
+                raise ValueError("Extra config is not a valid YAML dictionary.")
+            self.update(loaded)
 
-        self.validate()
+        try:
+            self.validate()
+        except MultiConfigurationError as e:
+            self._config_errors.extend(e.errors)
+        except ConfigurationError as e:
+            self._config_errors.append(e)
+
         return self
 
     def commit_to_beets(self) -> None:
@@ -277,6 +290,14 @@ class BeetsFlaskConfig(ConfigExtra[BeetsSchema]):
         if gui_globs is None or gui_globs == "_use_beets_ignore":
             gui_globs = self.data.ignore
         return cast(list[str], gui_globs)
+
+    @property
+    def errors(self) -> list[ConfigurationError]:
+        return getattr(self, "_config_errors", [])
+
+    @property
+    def is_healthy(self) -> bool:
+        return len(self.errors) == 0
 
 
 config: BeetsFlaskConfig | None = None

--- a/backend/beets_flask/server/websocket/__init__.py
+++ b/backend/beets_flask/server/websocket/__init__.py
@@ -3,7 +3,6 @@ from collections.abc import Callable
 from typing import cast
 
 import socketio
-from eyconf.validation import ConfigurationError, MultiConfigurationError
 
 from beets_flask.config import get_config
 from beets_flask.logger import log
@@ -44,14 +43,30 @@ def register_socketio(app):
 
     register_status()
 
-    terminal_enabled = True
-    try:
-        terminal_enabled = get_config().data.gui.terminal.enabled
-    except (MultiConfigurationError, ConfigurationError):
-        # We don't want to let the exception propagate here as it won't reach the frontend.
-        log.debug("Encountered config error. Will raise on next call to get_config()")
+    cfg = get_config()
+    if not cfg.is_healthy:
+        log.warning(
+            f"Config loaded with {len(cfg.errors)} error(s), app running on defaults"
+        )
 
-    if terminal_enabled:
+    @sio.on("connect")
+    async def on_connect(sid, environ):
+        """Push config health to every client on connection."""
+        current_cfg = get_config()
+        await sio.emit(
+            "config_status",
+            {
+                "healthy": current_cfg.is_healthy,
+                "errors": [
+                    {"message": e.message, "section": str(e.section)}
+                    for e in current_cfg.errors
+                ],
+            },
+            to=sid,
+        )
+
+    # Terminal setup uses the already-loaded config
+    if cfg.data.gui.terminal.enabled:
         log.info("Setting up Web-Terminal")
         from .terminal import register_tmux
 

--- a/backend/beets_flask/server/websocket/__init__.py
+++ b/backend/beets_flask/server/websocket/__init__.py
@@ -3,6 +3,7 @@ from collections.abc import Callable
 from typing import cast
 
 import socketio
+from eyconf.validation import ConfigurationError, MultiConfigurationError
 
 from beets_flask.config import get_config
 from beets_flask.logger import log
@@ -43,30 +44,16 @@ def register_socketio(app):
 
     register_status()
 
-    cfg = get_config()
-    if not cfg.is_healthy:
-        log.warning(
-            f"Config loaded with {len(cfg.errors)} error(s), app running on defaults"
-        )
+    terminal_enabled = True
+    try:
+        terminal_enabled = get_config().data.gui.terminal.enabled
+    except (MultiConfigurationError, ConfigurationError):
+        # We don't want to let the exception propagate here as it won't reach the frontend.
+        # We call the get_config function later in a route which wi ll propagate errors to
+        # the frontend
+        log.debug("Encountered config error. Will raise on next call to get_config()")
 
-    @sio.on("connect")
-    async def on_connect(sid, environ):
-        """Push config health to every client on connection."""
-        current_cfg = get_config()
-        await sio.emit(
-            "config_status",
-            {
-                "healthy": current_cfg.is_healthy,
-                "errors": [
-                    {"message": e.message, "section": str(e.section)}
-                    for e in current_cfg.errors
-                ],
-            },
-            to=sid,
-        )
-
-    # Terminal setup uses the already-loaded config
-    if cfg.data.gui.terminal.enabled:
+    if terminal_enabled:
         log.info("Setting up Web-Terminal")
         from .terminal import register_tmux
 

--- a/backend/tests/unit/test_config.py
+++ b/backend/tests/unit/test_config.py
@@ -106,6 +106,42 @@ class TestConfig:
         with open(beets_flask_path, "w") as f:
             f.write(content)
 
+    def test_config_can_handle_yaml_errors(self):
+        """Test that loading invalid config still works."""
+
+        config = get_config(force_reload=True)
+        beets_path = config.get_beets_config_path()
+        config.write_examples_as_user_defaults()
+        assert beets_path.exists()
+
+        with open(beets_path) as f:
+            content = f.read()
+        # use an unquoted template function in the paths section
+        invalid_yaml = """
+paths:
+    albumtype:compilation: %if{$test,Albums/$albumartist/,Compilations/}$album%aunique{}/$title
+        """
+        invalid_content = content + invalid_yaml
+        with open(beets_path, "w") as f:
+            f.write(invalid_content)
+
+        config.reload()
+        assert config.is_healthy == False
+        assert len(config.errors) == 1
+
+        # fix invalid value
+        valid_yaml = """
+paths:
+    albumtype:compilation: "%if{$test,Albums/$albumartist/,Compilations/}$album%aunique{}/$title"
+"""
+        valid_content = content + valid_yaml
+        with open(beets_path, "w") as f:
+            f.write(valid_content)
+
+        config.reload()
+        assert config.is_healthy == True
+        assert len(config.errors) == 0
+
     def test_commit_to_beets(self):
         """Test that committing to beets config works as expected."""
         import beets

--- a/backend/tests/unit/test_config.py
+++ b/backend/tests/unit/test_config.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 import yaml
 from eyconf.validation import MultiConfigurationError
+from eyconf.validation.exceptions import ConfigurationError
 
 from beets_flask.config import get_config
 
@@ -106,41 +107,20 @@ class TestConfig:
         with open(beets_flask_path, "w") as f:
             f.write(content)
 
-    def test_config_can_handle_yaml_errors(self):
-        """Test that loading invalid config still works."""
+    def test_reraise_yaml_errors(self, tmp_path):
+        """Yaml errors need to be raised as configuration errors!"""
+        invalid_config = tmp_path / "invalid_extra.yaml"
+        with open(invalid_config, "w") as f:
+            # use an unquoted template function in the paths section
+            f.write("""
+    paths:
+        albumtype:compilation: %if{$test,Albums/$albumartist/,Compilations/}$album%aunique{}/$title
+            """)
 
         config = get_config(force_reload=True)
-        beets_path = config.get_beets_config_path()
-        config.write_examples_as_user_defaults()
-        assert beets_path.exists()
 
-        with open(beets_path) as f:
-            content = f.read()
-        # use an unquoted template function in the paths section
-        invalid_yaml = """
-paths:
-    albumtype:compilation: %if{$test,Albums/$albumartist/,Compilations/}$album%aunique{}/$title
-        """
-        invalid_content = content + invalid_yaml
-        with open(beets_path, "w") as f:
-            f.write(invalid_content)
-
-        config.reload()
-        assert config.is_healthy == False
-        assert len(config.errors) == 1
-
-        # fix invalid value
-        valid_yaml = """
-paths:
-    albumtype:compilation: "%if{$test,Albums/$albumartist/,Compilations/}$album%aunique{}/$title"
-"""
-        valid_content = content + valid_yaml
-        with open(beets_path, "w") as f:
-            f.write(valid_content)
-
-        config.reload()
-        assert config.is_healthy == True
-        assert len(config.errors) == 0
+        with pytest.raises(ConfigurationError):
+            config.reload(invalid_config)
 
     def test_commit_to_beets(self):
         """Test that committing to beets config works as expected."""


### PR DESCRIPTION
This PR (backend only) addresses issues encountered in #304 

Currently if the parsing of the beets or beets-flask configs fails (yaml syntax, validation, etc)
the app crashes silently and fails to load the UI.
This is a poor user experience and paindul to diagnose.

In this PR we store any errors and provide them (via the socket)
back to the frontend for user examination

Leaving this as a draft as its incomplete (needs tests for backend)
Once the Tests are done this could be merged in and the frontend done separately

NOTE: I havent done much work with TypeScript so have no real idea how to capture/display/handle the "config_status"
message at app startup.

Im happy to work with anyone to move this forward. 
