### PR TITLE
Configure docker-compose for Synology NAS deployment

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -3,20 +3,13 @@ services:
         image: pspitzner/beets-flask:stable
         restart: unless-stopped
         ports:
-            - "5001:5001"
+            - "5006:5001"
         environment:
-            # Change to your timezone
-            TZ: "Europe/Berlin"
-            # 502 is default on macos, 1000 on linux
-            USER_ID: 1000
-            GROUP_ID: 1000
-            # Optional: Add extra groups to the beetle user for file permissions
-            # Format: "group_name1:gid1,group_name2:gid2"
-            # Example: EXTRA_GROUPS: "nas_shares:1001,media:1002"
+            TZ: "Europe/Paris"
+            USER_ID: 1026
+            GROUP_ID: 100
         volumes:
-            - /wherever/config/:/config
-            # for music folders, match paths inside and out of container!
-            - /music_path/inbox/:/music_path/inbox/
-            - /music_path/clean/:/music_path/clean/
-            # If you want to persist the logs, you can mount a logs directory
-            # - /wherever/logs/:/logs
+            - /volume1/docker/Music/beets-flask/config:/config
+            # for music folders, paths match inside and out of container!
+            - /volume1/docker/Music/MusicToTag:/volume1/docker/Music/MusicToTag
+            - /volume1/docker/Music/Music:/volume1/docker/Music/Music


### PR DESCRIPTION
## Summary

- Set TZ to Europe/Paris, USER_ID to 1026, GROUP_ID to 100
- Removed EXTRA_GROUPS (not needed for this setup)
- Changed external port from 5001 to 5006
- Set volume paths for Synology NAS under /volume1/docker/Music/
  - Config: /volume1/docker/Music/beets-flask/config
  - Inbox: /volume1/docker/Music/MusicToTag
  - Library: /volume1/docker/Music/Music
- Music paths mirrored on both sides so beets DB paths stay valid outside the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)