### PR TITLE
Fix time format in library view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed tmux terminal could not start in some environments if `SHELL` was not set currently. We now always start a bash shell [#282](https://github.com/pSpitzner/beets-flask/issues/282)
 - Container user `beetle` now uses bash terminal by default and activates the uv environment automatically.
 - Yaml syntax and parser errors are passed to the frontend for user examination instead of crashing before UI startup [#305](https://github.com/pSpitzner/beets-flask/pull/305)
-
+- Fixed an issue with timestamps shown in the library view [#289](https://github.com/pSpitzner/beets-flask/issues/289)
 
 ### Other (dev)
 

--- a/backend/beets_flask/server/routes/library/artists.py
+++ b/backend/beets_flask/server/routes/library/artists.py
@@ -95,9 +95,6 @@ def get_artists_polars(table: str, artist: str | None = None) -> pl.LazyFrame:
     # could minimize the ram usage
     df = pl.LazyFrame(rows, schema=["artist", "added"], orient="row")
 
-    # Convert added timestamps (beets stores as seconds, convert to milliseconds)
-    df = df.with_columns((pl.col("added") * 1000).alias("added"))
-
     # Split artist strings into lists and explode into separate rows
     if len(artist_separators()) > 0:
         # split does not yet support regex...
@@ -111,6 +108,7 @@ def get_artists_polars(table: str, artist: str | None = None) -> pl.LazyFrame:
         ).explode("artist")
 
     # Strip whitespace and process
+    # Convert added timestamps (beets stores as seconds, convert to milliseconds)
     df = df.with_columns(pl.col("artist").str.strip_chars(), pl.col("added") * 1000)
 
     # Group by artist and aggregate using lazy operations


### PR DESCRIPTION
This pull request addresses a bug with timestamp display in the library view and refactors the handling of timestamp conversion in the `get_artists_polars` function.

closes #289