### PR TITLE
Add ldconfig command for Debian installation

### DIFF
--- a/docs/plugins/installation.md
+++ b/docs/plugins/installation.md
@@ -56,6 +56,9 @@ cd keyfinder-cli/
 cmake -DCMAKE_INSTALL_PREFIX=/usr/local -S . -B build
 cmake --build build --parallel "$(nproc)"
 cmake --install build
+
+#reload available shared libraries in debian
+ldconfig
 ```
 
 Make the script executable:


### PR DESCRIPTION
Added instruction to reload shared libraries on Debian.

Otherwise /usr/local/bin/keyfinder-cli will error with: 

error while loading shared libraries: libkeyfinder.so.2: cannot open shared object file: No such file or directory
